### PR TITLE
Add filter to exclude metabox for a custom post type

### DIFF
--- a/index.php
+++ b/index.php
@@ -82,6 +82,10 @@ if ( !class_exists( "RichSnippets" ) )
 		function post_enqueue($hook) {
 			if( 'post.php' != $hook )
 				return;
+			$current_admin_screen = get_current_screen();
+			$exclude_custom_post_type = apply_filters( 'bsf_exclude_custom_post_type', array() );
+			if ( in_array( $current_admin_screen->post_type, $exclude_custom_post_type ) )
+				return;
 			wp_enqueue_script( 'jquery' );
 			wp_enqueue_script( 'bsf_jquery_star' );
 			wp_enqueue_script( 'bsf_toggle' );
@@ -96,6 +100,10 @@ if ( !class_exists( "RichSnippets" ) )
 		}
 		function post_new_enqueue($hook) {
 			if('post-new.php' != $hook )
+				return;
+			$current_admin_screen = get_current_screen();
+			$exclude_custom_post_type = apply_filters( 'bsf_exclude_custom_post_type', array() );
+			if ( in_array( $current_admin_screen->post_type, $exclude_custom_post_type ) )
 				return;
 			wp_enqueue_script( 'jquery' );
 			wp_enqueue_script( 'bsf_jquery_star' );

--- a/meta-boxes.php
+++ b/meta-boxes.php
@@ -19,7 +19,8 @@ function bsf_metaboxes( array $meta_boxes ) {
 	} 
 	else {
 
-		$required_post_type = $post_types;	
+		$exclude_custom_post_type = apply_filters( 'bsf_exclude_custom_post_type', array() );
+		$required_post_type = array_diff( $post_types, $exclude_custom_post_type );
 
 	}
 


### PR DESCRIPTION
Adds the ability to define a custom filter to exclude the plugin metabox for a custom post type. 

This change improves the compatibility with other plugins like SplitMagic, Custom Field Suite or Advanced Custom Fields (see issue #9) that make use of custom post types without support for an editor.

#### Usage within `functions.php`:
```php
add_filter( 'bsf_exclude_custom_post_type', 'exclude_splitmagic_custom_post_type' );
function exclude_splitmagic_custom_post_type() {

    return array( 'splitmagic_test' );

}
```