### PR TITLE
Resolve display issue for SIteOrigin generated pages that prevents snippets from displaying

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1060,7 +1060,7 @@ if ( class_exists( 'FLBuilderLoader' ) )
 {
 	add_filter('fl_builder_after_render_content','display_rich_snippet');
 }
-else{ add_filter('the_content','display_rich_snippet'); }
+else{ add_filter('the_content','display_rich_snippet', 20); }
 
 
 require_once(plugin_dir_path( __FILE__ ).'meta-boxes.php');


### PR DESCRIPTION
Currently, the Rich Snippet summary box won't appear on pages built using [SIteOrigin Page Builder](https://wordpress.org/plugins/siteorigin-panels/). This PR fixed this by increasing the default priority for the_content hook used to display the snippets.