### PR TITLE
Enqueue media scripts in a right way

### DIFF
--- a/index.php
+++ b/index.php
@@ -93,7 +93,8 @@ if ( !class_exists( "RichSnippets" ) )
 			wp_enqueue_style( 'star_style' );
 			wp_register_script( 'bsf-scripts', BSF_META_BOX_URL . 'js/cmb.js','', '0.9.1' );
 			wp_enqueue_script( 'bsf-scripts' );
-			wp_register_script( 'bsf-scripts-media', BSF_META_BOX_URL . 'js/media.js', array( 'jquery', 'media-upload', 'media-editor' ), '1.0' );
+			wp_enqueue_media();
+			wp_register_script( 'bsf-scripts-media', BSF_META_BOX_URL . 'js/media.js', array( 'jquery' ), '1.0' );
 			wp_enqueue_script( 'bsf-scripts-media' );
 			wp_enqueue_script('jquery-ui-datepicker');
 			if(!function_exists('vc_map'))
@@ -112,7 +113,8 @@ if ( !class_exists( "RichSnippets" ) )
 			wp_enqueue_style( 'star_style' );
 			wp_register_script( 'bsf-scripts', BSF_META_BOX_URL . 'js/cmb.js', '', '0.9.1' );
 			wp_enqueue_script( 'bsf-scripts' );
-			wp_register_script( 'bsf-scripts-media', BSF_META_BOX_URL . 'js/media.js', array( 'jquery', 'media-upload', 'media-editor' ), '1.0' );
+			wp_enqueue_media();
+			wp_register_script( 'bsf-scripts-media', BSF_META_BOX_URL . 'js/media.js', array( 'jquery' ), '1.0' );
 			wp_enqueue_script( 'bsf-scripts-media' );
 			wp_enqueue_script('jquery-ui-datepicker');
 			if(!function_exists('vc_map'))


### PR DESCRIPTION
Fix to media scripts integration.

Current way of enqueue fails on custom post type pages (new post and edit post), showing JS errors. With some free seo plugin installed a complete blank new post area is shown.