### PR TITLE
publisher logo alt tag

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -821,7 +821,7 @@ function display_rich_snippet($content) {
 						$article .= '<div class="snippet-label-img">'.esc_attr( stripslashes(  $args_article['article_publisher_logo'] ) ).'</div>';
 
 					$article .= '<div class="snippet-data-img publisher-logo" itemprop="logo" itemscope itemtype="https://schema.org/ImageObject">';
-					$article .= '<img width="180" src="'.esc_url( $article_publisher_logo ).'"/>';
+					$article .= '<img width="180" src="'.esc_url( $article_publisher_logo ).'" alt="'.esc_attr( $article_publisher ).'" />';
 					$article .=	'<meta itemprop="url" content="'.esc_attr( $article_publisher_logo ).'">';
 					$article .=	'</div>';
 				}


### PR DESCRIPTION
Adding an alt tag to the publisher image, to make SEMrush happy.

Related to #16 

Also mentioned here: 
https://wordpress.org/support/topic/semrush-indicates-missing-alt-tag-on-publisher-logo/