### PR TITLE
Fix bsf_update_rating functions

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1106,7 +1106,14 @@ function bsf_update_rating()
 	
 	$postid = esc_attr( $_POST['post_id'] );
 	
-	$prev_data = get_post_meta($postid,'post-rating',true);
+	$prev_data = get_post_meta( $postid, 'post-rating', false );
+
+	foreach ( $prev_data as $data ) {
+		if ( $ip == $data['user_ip'] ) {
+			$prev_data = $data;
+			break;
+		}
+	}
 	
 	$user_rating = array('post_id' => $postid, 'user_ip' => $ip, 'user_rating' => $stars);
 	


### PR DESCRIPTION
In in original code, $prev_data is always get first rating from database.
In my fix $prev_data value based on $ip. My code always updates the correct rating - not the first one.