### PR TITLE
Update index.php for text-domain issue

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,7 +6,7 @@
  * Author URI: https://www.brainstormforce.com
  * Description: Welcome to the Schema - All In One Schema Rich Snippets! You can now easily add schema markup on various * pages and posts of your website. Implement schema types such as Review, Events, Recipes, Article, Products, Services * *etc.
  * Version: 1.6.4
- * Text Domain: rich-snippets
+ * Text Domain: all-in-one-schemaorg-rich-snippets
  * License: GPL2
  *
  * @package AIOSRS.
@@ -206,7 +206,7 @@ if ( ! class_exists( 'RichSnippets' ) ) {
 		 */
 		public function rich_snippet_translation() {
 			// Load Translation File.
-			load_plugin_textdomain( 'rich-snippets', false, basename( dirname( __FILE__ ) ) . '/lang/' );
+			load_plugin_textdomain( 'all-in-one-schemaorg-rich-snippets', false, basename( dirname( __FILE__ ) ) . '/lang/' );
 		}
 		/**
 		 * Register_bsf_settings.


### PR DESCRIPTION
This plugin's slug is `all-in-one-schemaorg-rich-snippets`, but your Text Domain is `rich-snippets`. Change your Text Domain so it is equal to your slug and modify the text domain in all your source files. This change is needed because your "Requires at least" is below 4.6. See [https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains)

I think these changes can also trigger the plugin's GlotPress project to update strings to 339 items (current items are 254).