### PR TITLE
AST-3288 - Fix: Customiser not loading when all-in-one-schemaorg-rich-snippets plugin is active.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Donate link:** https://www.paypal.me/BrainstormForce
 **Tags:** schema markup, structured data, rich snippets, schema.org, Microdata, schema
 **Requires at least:** 3.7
-**Tested up to:** 6.2
+**Tested up to:** 6.2.2
 **Stable tag:** 1.6.7
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** schema markup, structured data, rich snippets, schema.org, Microdata, schema
 **Requires at least:** 3.7
 **Tested up to:** 6.2
-**Stable tag:** 1.6.6
+**Stable tag:** 1.6.7
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 Boost CTR. Improve SEO & Rankings. Supports most of the content type. Works perfectly with Google, Bing, Yahoo & Facebook.
@@ -80,6 +80,8 @@ Review, Event, People, Product, Recipe, Software Application, Video, Articles et
 
 ## Changelog ##
 
+### 1.6.7 ###
+- Fixed - Customizer not loading when All In One Schema Rich Snippets plugin is active.
 ### 1.6.6 ###
 - Props to Patchstack for reporting security issues. Those are fixed in this release. Plus we've hardened security in other areas of the plugin.
 ### 1.6.5 ###

--- a/index.php
+++ b/index.php
@@ -5,7 +5,7 @@
  * Author: Brainstorm Force
  * Author URI: https://www.brainstormforce.com
  * Description: Welcome to the Schema - All In One Schema Rich Snippets! You can now easily add schema markup on various * pages and posts of your website. Implement schema types such as Review, Events, Recipes, Article, Products, Services * *etc.
- * Version: 1.6.6
+ * Version: 1.6.7
  * Text Domain: rich-snippets
  * License: GPL2
  *
@@ -68,7 +68,7 @@ if ( ! class_exists( 'RichSnippets' ) ) {
 			define( 'AIOSRS_PRO_BASE', plugin_basename( AIOSRS_PRO_FILE ) );
 			define( 'AIOSRS_PRO_DIR', plugin_dir_path( AIOSRS_PRO_FILE ) );
 			define( 'AIOSRS_PRO_URI', plugins_url( '/', AIOSRS_PRO_FILE ) );
-			define( 'AIOSRS_PRO_VER', '1.6.6' );
+			define( 'AIOSRS_PRO_VER', '1.6.7' );
 		}
 
 		/**

--- a/init.php
+++ b/init.php
@@ -588,7 +588,7 @@ add_filter( 'get_media_item_args', 'bsf_force_send' );
 function bsf_force_send( $args ) {
 
 	if ( ! isset( $_GET['bsf_file_upload_nonce'] ) || ! wp_verify_nonce( $_GET['bsf_file_upload_nonce'], 'ajax_nonce' ) ) {
-		return;
+		return $args;
 	}
 	// if the Gallery tab is opened from a custom meta box field, add Insert Into Post button.
 	if ( isset( $_GET['bsf_force_send'] ) && 'true' == esc_attr( $_GET['bsf_force_send'] ) ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "all-in-one-schemaorg-rich-snippets",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "main": "Gruntfile.js",
   "author": "Brainstorm Force",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Tags: schema markup, structured data, rich snippets, schema.org, Microdata, schema
 Requires at least: 3.7
 Tested up to: 6.2
-Stable tag: 1.6.6
+Stable tag: 1.6.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Boost CTR. Improve SEO & Rankings. Supports most of the content type. Works perfectly with Google, Bing, Yahoo & Facebook.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: brainstormforce
 Donate link: https://www.paypal.me/BrainstormForce
 Tags: schema markup, structured data, rich snippets, schema.org, Microdata, schema
 Requires at least: 3.7
-Tested up to: 6.2
+Tested up to: 6.2.2
 Stable tag: 1.6.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,9 @@ Review, Event, People, Product, Recipe, Software Application, Video, Articles et
 
 == Changelog ==
 
+= 1.6.7 =
+- Fixed - Customizer not loading when All In One Schema Rich Snippets plugin is active.
+
 = 1.6.6 =
 - Props to Patchstack for reporting security issues. Those are fixed in this release. Plus we've hardened security in other areas of the plugin.
 


### PR DESCRIPTION
- Customiser not loading when the all-in-one-schemaorg-rich-snippets plugin is active.