### PR TITLE
Add analytics migration and advanced settings

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -94,8 +94,9 @@ function rich_snippet_dashboard() {
 			<li><a href="#tab-4" class="nav-tab">' . esc_html__( 'Customization', 'rich-snippets' ) . '</a></li>
 
 			<li><a href="#tab-3" class="nav-tab">' . esc_html__( 'FAQs', 'rich-snippets' ) . '</a></li>
-			<li><a href="#tab-5" class="nav-tab">' . esc_html__( 'Getting Started', 'rich-snippets' ) . '</a></li>
-		 </ul>
+                        <li><a href="#tab-5" class="nav-tab">' . esc_html__( 'Getting Started', 'rich-snippets' ) . '</a></li>
+                        <li><a href="#tab-6" class="nav-tab">' . esc_html__( 'Advanced Settings', 'rich-snippets' ) . '</a></li>
+                 </ul>
 		 <div class="clear"></div>
 		 <div class="panel-container bsf-panel">
 			 <div id="tab-1">
@@ -871,13 +872,38 @@ function rich_snippet_dashboard() {
 				</table>
 			</form>
 			</div>
-	</div>';
+        </div>';
+        echo '<div id="tab-6">
+                <div id="poststuff">
+                        <div id="postbox-container-18" class="postbox-container">
+                                <div class="postbox">
+                                        <h3 class="hndle"><span>' . esc_html__( 'Advanced Settings', 'rich-snippets' ) . '</span></h3>
+                                        <div class="inside">
+                                                <form id="aiosrs_advanced_form" method="post">
+                                                        <input type="hidden" name="aiosrs_advanced_nonce_field" value="' . esc_attr( wp_create_nonce( 'aiosrs_advanced_form_action' ) ) . '" />
+                                                        <table class="bsf_metabox">
+                                                                <tr>
+                                                                        <td>
+                                                                                <input type="checkbox" name="aiosrs_analytics_optin" id="aiosrs_analytics_optin" value="yes" ' . checked( 'yes', get_option( 'aiosrs_analytics_optin', 'no' ), false ) . ' />
+                                                                                <label for="aiosrs_analytics_optin">' . esc_html__( 'Enable feature', 'rich-snippets' ) . '</label>
+                                                                        </td>
+                                                                </tr>
+                                                                <tr>
+                                                                        <td><input type="submit" class="button-primary" name="aiosrs_advanced_submit" value="' . esc_html__( 'Save', 'rich-snippets' ) . '" /></td>
+                                                                </tr>
+                                                        </table>
+                                                </form>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        </div>';
 
-	$allowed_html = array(
-		'div'      => array(
-			'class' => array(),
-			'id'    => array(),
-		),
+        $allowed_html = array(
+                'div'      => array(
+                        'class' => array(),
+                        'id'    => array(),
+                ),
 		'button'   => array(
 			'type'          => array(),
 			'class'         => array(),
@@ -1112,9 +1138,19 @@ if ( isset( $_POST['service_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_service', $args );
-		display_status( $status );
-	}
+        $status = update_option( 'bsf_service', $args );
+        display_status( $status );
+        }
+}
+if ( isset( $_POST['aiosrs_advanced_submit'] ) ) {
+        if ( ! isset( $_POST['aiosrs_advanced_nonce_field'] ) || ! wp_verify_nonce( $_POST['aiosrs_advanced_nonce_field'], 'aiosrs_advanced_form_action' ) || ! current_user_can( 'manage_options' ) ) {
+                print 'Sorry, your nonce did not verify.';
+                exit;
+        } else {
+                $value  = isset( $_POST['aiosrs_analytics_optin'] ) ? 'yes' : 'no';
+                $status = update_option( 'aiosrs_analytics_optin', $value );
+                display_status( $status );
+        }
 }
 /**
  * Display status.

--- a/admin/index.php
+++ b/admin/index.php
@@ -971,11 +971,12 @@ function rich_snippet_dashboard() {
 	jQuery("#postbox-container-7").css("width","35%");
 	jQuery("#postbox-container-8").css("width","35%");
 	jQuery("#postbox-container-9").css("width","35%");
-	jQuery("#postbox-container-10").css("width","35%");
-	jQuery("#postbox-container-11").css({"width":"87%","padding-right":"2%"});
-	jQuery(".postbox h3").click( function() {
-   		jQuery(jQuery(this).parent().get(0)).toggleClass("closed");
-   	});
+        jQuery("#postbox-container-10").css("width","35%");
+        jQuery("#postbox-container-11").css({"width":"87%","padding-right":"2%"});
+        jQuery("#postbox-container-18").css("width","35%");
+        jQuery(".postbox h3").click( function() {
+                jQuery(jQuery(this).parent().get(0)).toggleClass("closed");
+        });
 	jQuery(".handlediv").click( function() {
    		jQuery(jQuery(this).parent().get(0)).toggleClass("closed");
    	});

--- a/index.php
+++ b/index.php
@@ -46,7 +46,9 @@ if ( ! class_exists( 'RichSnippets' ) ) {
 			add_action( 'admin_menu', array( $this, 'register_custom_menu_page' ) );
 			add_action( 'admin_init', array( $this, 'set_styles' ) );
 
-			add_action( 'admin_init', array( $this, 'bsf_color_scripts' ) );
+                        add_action( 'admin_init', array( $this, 'bsf_color_scripts' ) );
+
+                        add_action( 'admin_init', array( $this, 'aiosrs_maybe_migrate_analytics_tracking' ) );
 
 			add_filter( 'plugins_loaded', array( $this, 'rich_snippet_translation' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'post_enqueue' ) );
@@ -363,8 +365,8 @@ if ( ! class_exists( 'RichSnippets' ) ) {
 		/**
 		 * Bsf_color_scripts.
 		 */
-		public function bsf_color_scripts() {
-			global $wp_version;
+                public function bsf_color_scripts() {
+                        global $wp_version;
 			$bsf_script_array = array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'media-upload', 'thickbox' );
 
 			// styles required for cmb.
@@ -382,9 +384,26 @@ if ( ! class_exists( 'RichSnippets' ) ) {
 				$bsf_script_array[] = 'farbtastic';
 				$bsf_style_array[]  = 'farbtastic';
 
-			}
-		}
-	}
+                        }
+                }
+
+                /**
+                 * Migrate analytics tracking option from old bsf key to new one.
+                 *
+                 * @return void
+                 */
+                public function aiosrs_maybe_migrate_analytics_tracking() {
+                        $old_tracking = get_option( 'bsf_analytics_optin', false );
+                        $new_tracking = get_option( 'aiosrs_analytics_optin', false );
+                        if ( 'yes' === $old_tracking && false === $new_tracking ) {
+                                update_option( 'aiosrs_analytics_optin', 'yes' );
+                                $time = get_option( 'bsf_analytics_installed_time' );
+                                if ( $time ) {
+                                        update_option( 'aiosrs_analytics_installed_time', $time );
+                                }
+                        }
+                }
+        }
 }
 	require_once plugin_dir_path( __FILE__ ) . 'functions.php';
 if ( is_admin() ) {
@@ -405,8 +424,8 @@ if ( ! class_exists( 'BSF_Analytics_Loader' ) ) {
 $bsf_analytics = BSF_Analytics_Loader::get_instance();
 
 $bsf_analytics->set_entity(
-	array(
-		'bsf' => array(
+        array(
+                'aiosrs' => array(
 			'product_name'        => 'All In One Schema Rich Snippets',
 			'path'                => plugin_dir_path( __FILE__ ) . 'admin/bsf-analytics',
 			'author'              => 'Brainstorm Force',


### PR DESCRIPTION
## Summary
- add advanced settings tab in admin interface
- migrate old analytics option to new `aiosrs_analytics_optin`
- provide checkbox with save button for analytics tracking

## Testing
- `composer lint` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68511b8dc34c8330a5b6fa793e19e182