### PR TITLE
Fix advanced settings tab width

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -844,11 +844,37 @@ function rich_snippet_dashboard() {
 							</div>
 					</div>
 				</div>
-			</div>
+                        </div>
 
-		 </div>
-		 </div>
-		<div class="postbox-container" id="bsf-postbox-container-1" >
+                        <div id="tab-6">
+                                <div id="poststuff">
+                                        <div id="postbox-container-18" class="postbox-container">
+                                                <div class="postbox">
+                                                        <h3 class="hndle"><span>' . esc_html__( 'Advanced Settings', 'rich-snippets' ) . '</span></h3>
+                                                        <div class="inside">
+                                                                <form id="aiosrs_advanced_form" method="post">
+                                                                        <input type="hidden" name="aiosrs_advanced_nonce_field" value="' . esc_attr( wp_create_nonce( 'aiosrs_advanced_form_action' ) ) . '" />
+                                                                        <table class="bsf_metabox">
+                                                                                <tr>
+                                                                                        <td>
+                                                                                                <input type="checkbox" name="aiosrs_analytics_optin" id="aiosrs_analytics_optin" value="yes" ' . checked( 'yes', get_option( 'aiosrs_analytics_optin', 'no' ), false ) . ' />
+                                                                                                <label for="aiosrs_analytics_optin">' . esc_html__( 'Enable feature', 'rich-snippets' ) . '</label>
+                                                                                        </td>
+                                                                                </tr>
+                                                                                <tr>
+                                                                                        <td><input type="submit" class="button-primary" name="aiosrs_advanced_submit" value="' . esc_html__( 'Save', 'rich-snippets' ) . '" /></td>
+                                                                                </tr>
+                                                                        </table>
+                                                                </form>
+                                                        </div>
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
+
+                 </div>
+                 </div>
+                <div class="postbox-container" id="bsf-postbox-container-1" >
 		<div id="side-sortables" class="meta-box-sortables ui-sortable">
 		<div class="postbox bsf-woocommerce-setting closed">
 			<button type="button" class="handlediv" aria-expanded="false"><span class="screen-reader-text">' . esc_html__( 'Toggle panel: Frontend Options', 'rich-snippets' ) . '</span><span class="toggle-indicator" aria-hidden="true"></span></button>

--- a/index.php
+++ b/index.php
@@ -50,6 +50,8 @@ if ( ! class_exists( 'RichSnippets' ) ) {
 
                         add_action( 'admin_init', array( $this, 'aiosrs_maybe_migrate_analytics_tracking' ) );
 
+                        add_action( 'admin_init', array( $this, 'aiosrs_remove_general_usage_tracking_field' ), 15 );
+
 			add_filter( 'plugins_loaded', array( $this, 'rich_snippet_translation' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'post_enqueue' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'post_new_enqueue' ) );
@@ -402,6 +404,24 @@ if ( ! class_exists( 'RichSnippets' ) ) {
                                         update_option( 'aiosrs_analytics_installed_time', $time );
                                 }
                         }
+                }
+
+                /**
+                 * Remove usage tracking checkbox from WordPress General settings.
+                 *
+                 * @since 1.7.2
+                 * @return void
+                 */
+                public function aiosrs_remove_general_usage_tracking_field() {
+                        global $wp_settings_fields;
+
+                        $field_id = 'aiosrs-analytics-optin';
+
+                        if ( isset( $wp_settings_fields['general']['default'][ $field_id ] ) ) {
+                                unset( $wp_settings_fields['general']['default'][ $field_id ] );
+                        }
+
+                        unregister_setting( 'general', 'aiosrs_analytics_optin' );
                 }
         }
 }


### PR DESCRIPTION
## Summary
- ensure new Advanced Settings pane is visible by assigning width to its container
- move advanced settings markup inside the tab container so it only displays when tab is active
- migrate old analytics setting to new key
- remove usage tracking checkbox from general settings page

## Testing
- `composer lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68511b8dc34c8330a5b6fa793e19e182