### PR TITLE
Fix analytics opt-in box width

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -876,18 +876,20 @@ function rich_snippet_dashboard() {
 		     <div id="tab-6">
                                 <div id="poststuff">
                                         <div id="postbox-container-18" class="postbox-container">
-                                                <div class="postbox">
-                                                        <h3 class="hndle"><span>' . esc_html__( 'Help Us Improve Your Experience.', 'rich-snippets' ) . '</span></h3>
+                                                <div class="postbox bsf-contact closed">
+                                                        <button type="button" class="handlediv" aria-expanded="false"><span class="screen-reader-text">' . esc_html__( 'Toggle panel: Frontend Options', 'rich-snippets' ) . '</span><span class="toggle-indicator" aria-hidden="true"></span></button>
+                                                        <h3 class="get_in_touch">' . esc_html__( 'Help Us Improve Your Experience.', 'rich-snippets' ) . '</h3>
                                                         <div class="inside">
                                                                 <form id="aiosrs_advanced_form" method="post">
                                                                         <input type="hidden" name="aiosrs_advanced_nonce_field" value="' . esc_attr( wp_create_nonce( 'aiosrs_advanced_form_action' ) ) . '" />
+                                                                        <p>' . wp_kses_post( __( 'Collect non-sensitive information from your website, such as the PHP version and features used, to help us fix bugs faster, make smarter decisions, and build features that actually matter to you. <a href="https://store.brainstormforce.com/usage-tracking/?utm_source=wp_dashboard&utm_medium=general_settings&utm_campaign=usage_tracking" target="_blank">Learn More</a>', 'rich-snippets' ) ) . '</p>
                                                                         <table class="bsf_metabox">
-       <tr>
-              <td style="display: flex; width: 565px;">
-    <label for="aiosrs_analytics_optin">' . wp_kses_post( __( 'Collect non-sensitive information from your website, such as the PHP version and features used, to help us fix bugs faster, make smarter decisions, and build features that actually matter to you. <a href="https://store.brainstormforce.com/usage-tracking/?utm_source=wp_dashboard&utm_medium=general_settings&utm_campaign=usage_tracking" target="_blank">Learn More</a>', 'rich-snippets' ) ) . '</label>
-    <input style="margin-left:10px;" type="checkbox" name="aiosrs_analytics_optin" id="aiosrs_analytics_optin" value="yes" ' . checked( 'yes', get_option( 'aiosrs_analytics_optin', 'no' ), false ) . ' />
-</td>
-       </tr>
+                                                                                <tr>
+                                                                                        <td>
+                                                                                                <input type="checkbox" name="aiosrs_analytics_optin" id="aiosrs_analytics_optin" value="yes" ' . checked( 'yes', get_option( 'aiosrs_analytics_optin', 'no' ), false ) . ' />
+                                                                                                <label for="aiosrs_analytics_optin">' . esc_html__( 'Yes, I agree', 'rich-snippets' ) . '</label>
+                                                                                        </td>
+                                                                                </tr>
                                                                                 <tr>
                                                                                         <td><input type="submit" class="button-primary" name="aiosrs_advanced_submit" value="' . esc_html__( 'Save', 'rich-snippets' ) . '" style="margin-top: 15px;" /></td>
                                                                                 </tr>


### PR DESCRIPTION
## Summary
- make analytics opt-in section match WooCommerce settings styling

## Testing
- `composer run lint` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_b_68527b0a8b1883309cb0786d665a7410