### PR TITLE
fix: add capability checks to AJAX handlers

### DIFF
--- a/index.php
+++ b/index.php
@@ -288,24 +288,22 @@ if ( ! class_exists( 'RichSnippets' ) ) {
 		 * Submit_request.
 		 */
 		public function submit_request() {
-			$to       = 'Brainstorm Force <support@bsf.io>';
-			$from     = '';
-			$site     = '';
-			$sub      = '';
-			$message  = '';
-			$post_url = '';
-			$name     = '';
-			$subject  = ''; // Initialize $subject.
-
-			if ( isset( $_POST['aiosrs_support_form_nonce'] ) && wp_verify_nonce( $_POST['aiosrs_support_form_nonce'], 'aiosrs_support_form' ) ) {
-
-				$from     = sanitize_email( $_POST['email'] );
-				$site     = esc_url( $_POST['site_url'] );
-				$sub      = sanitize_text_field( $_POST['subject'] );
-				$message  = esc_html( $_POST['message'] );
-				$name     = sanitize_text_field( $_POST['name'] );
-				$post_url = esc_url( $_POST['post_url'] );
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_send_json_error( __( 'Unauthorized access.', 'rich-snippets' ) );
 			}
+
+			if ( ! isset( $_POST['aiosrs_support_form_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['aiosrs_support_form_nonce'] ) ), 'aiosrs_support_form' ) ) {
+				wp_send_json_error( __( 'Security check failed.', 'rich-snippets' ) );
+			}
+
+			$to       = 'Brainstorm Force <support@bsf.io>';
+			$from     = sanitize_email( $_POST['email'] );
+			$site     = esc_url( $_POST['site_url'] );
+			$sub      = sanitize_text_field( $_POST['subject'] );
+			$message  = esc_html( $_POST['message'] );
+			$name     = sanitize_text_field( $_POST['name'] );
+			$post_url = esc_url( $_POST['post_url'] );
+			$subject  = '';
 
 			if ( 'question' == $sub ) {
 				$subject = '[AIOSRS] New question received from ' . $name;

--- a/init.php
+++ b/init.php
@@ -644,7 +644,11 @@ add_action( 'wp_ajax_bsf_oembed_handler', 'bsf_oembed_ajax_results' );
  */
 function bsf_oembed_ajax_results() {
 	// verify our nonce.
-	if ( ! ( isset( $_REQUEST['bsf_ajax_nonce'], $_REQUEST['oembed_url'] ) && wp_verify_nonce( $_REQUEST['bsf_ajax_nonce'], 'ajax_nonce' ) ) ) {
+	if ( ! ( isset( $_REQUEST['bsf_ajax_nonce'], $_REQUEST['oembed_url'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['bsf_ajax_nonce'] ) ), 'ajax_nonce' ) ) ) {
+		die();
+	}
+	// verify capability.
+	if ( ! current_user_can( 'edit_posts' ) ) {
 		die();
 	}
 	// sanitize our search string.


### PR DESCRIPTION
## Summary
- Add `current_user_can('manage_options')` to `submit_request` AJAX handler
- Add `current_user_can('edit_posts')` to `bsf_oembed_ajax_results` AJAX handler
- Fix `submit_request` control flow: bail early on nonce failure instead of running `wp_mail()` with empty fields
- Add `sanitize_text_field(wp_unslash())` to nonce verification inputs

## Test plan
- [ ] Verify support form still works for admins
- [ ] Verify subscribers cannot access the support form AJAX endpoint
- [ ] Verify oEmbed preview still works on post edit screens
- [ ] Verify subscribers cannot call the oEmbed AJAX endpoint

Fixes #218