### PR TITLE
fix: use capability instead of role in add_menu_page

### DIFF
--- a/index.php
+++ b/index.php
@@ -107,7 +107,7 @@ if ( ! class_exists( 'RichSnippets' ) ) {
 		 */
 		public function register_custom_menu_page() {
 			require_once plugin_dir_path( __FILE__ ) . 'admin/index.php';
-			$page = add_menu_page( __( 'All in One Rich Snippets Dashboard', 'rich-snippets' ), __( 'Rich Snippets', 'rich-snippets' ), 'administrator', 'rich_snippet_dashboard', 'rich_snippet_dashboard', 'div' );
+			$page = add_menu_page( __( 'All in One Rich Snippets Dashboard', 'rich-snippets' ), __( 'Rich Snippets', 'rich-snippets' ), 'manage_options', 'rich_snippet_dashboard', 'rich_snippet_dashboard', 'div' );
 			// Call the function to print the stylesheets and javascripts in only this plugins admin area.
 			add_action( 'admin_print_styles-' . $page, 'bsf_admin_styles' );
 			add_action( 'admin_print_scripts-' . $page, array( $this, 'iris_enqueue_scripts' ) );


### PR DESCRIPTION
## Summary
Replace deprecated `'administrator'` role string with `'manage_options'` capability in `add_menu_page()` call. Using role names as capabilities is deprecated WordPress behavior and may fail on custom installations or multisite.

## Test plan
- [ ] Verify Rich Snippets admin menu is visible for administrators
- [ ] Verify menu is hidden for editors/subscribers

Fixes #221