### PR TITLE
fix: prevent information disclosure in error handling

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -883,9 +883,10 @@ function display_rich_snippet( $content ) {
 					$datetime   = new DateTime( $video_date, new DateTimeZone( $timezone ) ); // Set the timezone to the server's timezone.
 					$uploadDate = $datetime->format( 'd-m-Y\TH:i:sP' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 				} catch ( Exception $e ) {
-					// Translators: %s is the error message from the exception.
-					echo esc_html( sprintf( __( 'Error creating DateTime object: %s', 'rich-snippets' ), esc_html( $e->getMessage() ) ) );
-					return;
+					// Log the error instead of displaying it to frontend visitors.
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					error_log( 'AIOSRS: Error creating DateTime object: ' . $e->getMessage() );
+					return $content;
 				}
 			}
 		}

--- a/init.php
+++ b/init.php
@@ -665,7 +665,7 @@ function bsf_oembed_ajax_results() {
 		$fallback = $wp_embed->maybe_make_link( $oembed_url );
 		if ( $check_embed && $check_embed != $fallback ) {
 			// Embed data.
-			$return = '<div class="embed_status">' . $check_embed . '<a href="#" class="bsf_remove_file_button" rel="' . esc_attr( $_REQUEST['field_id'] ) . '">' . __( 'Remove Embed', 'rich-snippets' ) . '</a></div>';
+			$return = '<div class="embed_status">' . $check_embed . '<a href="#" class="bsf_remove_file_button" rel="' . esc_attr( sanitize_text_field( wp_unslash( $_REQUEST['field_id'] ) ) ) . '">' . __( 'Remove Embed', 'rich-snippets' ) . '</a></div>';
 			// set our response id.
 			$found = 'found';
 		} else {


### PR DESCRIPTION
## Summary
- Replace DateTime exception `echo` with `error_log()` to prevent leaking PHP internals (file paths, timezone info) to unauthenticated frontend visitors
- Return `$content` unchanged on error instead of bare `return`
- Sanitize `field_id` parameter in oEmbed AJAX response with `sanitize_text_field(wp_unslash())` before output

## Test plan
- [ ] Verify video schema still renders correctly on frontend
- [ ] Verify invalid video dates are handled gracefully (no visible error)
- [ ] Check error log for DateTime errors instead of frontend output
- [ ] Verify oEmbed embed/remove still works in post editor

Fixes #222