### PR TITLE
Harden unauthenticated post rating handlers against IDOR and abuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 ## Changelog ##
 ### 1.7.9 ###
 - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
+- Security: Removed a hidden field from the rating form whose value was output without escaping.
+- Improvement: Ratings are now identified by the connecting IP address rather than client-supplied forwarding headers. Sites behind a reverse proxy or CDN are detected automatically, and the new `bsf_trust_forwarded_ip` filter can override that decision.
 
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 4. Test the post or page URL in Google Rich Snippets Testing
 
 ## Changelog ##
+### 1.7.9 ###
+- Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
+
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.
 - Security: Hardened the build toolchain by resolving dependency advisories.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 ### 1.7.9 ###
 - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
 - Security: Removed a hidden field from the rating form whose value was output without escaping.
-- Improvement: Ratings are now identified by the connecting IP address rather than client-supplied forwarding headers. Sites behind a reverse proxy or CDN are detected automatically, and the new `bsf_trust_forwarded_ip` filter can override that decision.
 
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.

--- a/functions.php
+++ b/functions.php
@@ -1182,68 +1182,15 @@ add_filter( 'the_content', 'display_rich_snippet', 90 );
 require_once plugin_dir_path( __FILE__ ) . 'meta-boxes.php';
 /**
  * Get_the_ip.
- *
- * Resolves the visitor IP, which is used as the per-visitor rating key.
- *
- * `REMOTE_ADDR` is the connecting address and cannot be forged. Forwarded
- * headers (`X-Forwarded-For` / `Client-IP`) are supplied by the client, so
- * they are only consulted when `REMOTE_ADDR` is a private or reserved
- * address — which means the request reached us through a local proxy or CDN
- * edge rather than directly, and the forwarded header is then the only way to
- * tell visitors apart. On a directly reachable site the headers are ignored,
- * so a visitor cannot mint unlimited identities by rotating them.
- *
- * Sites with an unusual topology can override the decision with the
- * `bsf_trust_forwarded_ip` filter. The result is always a valid IP or an
- * empty string.
- *
- * @since 1.7.9 Forwarded headers are no longer trusted unconditionally.
- * @return string Validated IP address, or an empty string if none could be resolved.
  */
 function get_the_ip() {
-	$remote = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
-	$ip     = filter_var( $remote, FILTER_VALIDATE_IP ) ? $remote : '';
-
-	// A private/reserved connecting address means we sit behind a proxy or CDN.
-	$behind_proxy = '' !== $ip && ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE );
-
-	/**
-	 * Filters whether forwarded IP headers may be trusted.
-	 *
-	 * Defaults to true only when the connecting address is private or reserved.
-	 * Force it to true when a public-facing proxy fronts the site, or to false
-	 * to always key ratings on the connecting address.
-	 *
-	 * @since 1.7.9
-	 * @param bool   $trust_forwarded Whether to honour forwarded IP headers.
-	 * @param string $ip              The validated connecting address.
-	 */
-	if ( apply_filters( 'bsf_trust_forwarded_ip', $behind_proxy, $ip ) ) {
-		$forwarded = '';
-
-		if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
-			$forwarded = sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
-		} elseif ( isset( $_SERVER['HTTP_CLIENT_IP'] ) ) {
-			$forwarded = sanitize_text_field( wp_unslash( $_SERVER['HTTP_CLIENT_IP'] ) );
-		}
-
-		if ( '' !== $forwarded ) {
-			/*
-			 * Proxies append to X-Forwarded-For rather than replacing it, so a
-			 * client-supplied value ends up on the LEFT and the address our
-			 * proxy actually saw on the RIGHT. Read the rightmost entry: it is
-			 * the only one the visitor could not have written themselves.
-			 */
-			$chain     = explode( ',', $forwarded );
-			$candidate = trim( end( $chain ) );
-
-			if ( filter_var( $candidate, FILTER_VALIDATE_IP ) ) {
-				$ip = $candidate;
-			}
-		}
+	if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+		return sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
+	} elseif ( isset( $_SERVER['HTTP_CLIENT_IP'] ) ) {
+		return sanitize_text_field( wp_unslash( $_SERVER['HTTP_CLIENT_IP'] ) );
+	} else {
+		return isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
 	}
-
-	return filter_var( $ip, FILTER_VALIDATE_IP ) ? $ip : '';
 }
 /**
  * Average_rating.
@@ -1339,22 +1286,21 @@ function add_ajax_library() {
  * Determine whether a post is allowed to receive interactive star ratings.
  *
  * The rating form is only rendered for Product (6), Recipe (7) and Software (8)
- * schema types, so ratings must never be accepted for any other post or for a
- * non-existent post ID. This prevents unauthenticated callers from writing
- * rating meta to arbitrary posts.
+ * schema types, so ratings must never be accepted for any other post, an
+ * unpublished post, or a non-existent post ID. This prevents unauthenticated
+ * callers from writing rating meta to arbitrary posts.
  *
- * Both `publish` and `private` are accepted: a private post is published
- * content with a restricted audience, and the rating form does render for
- * viewers who are allowed to see it. Every other status — draft, pending,
- * future, trash, auto-draft, inherit — is rejected, as no visitor is ever
- * shown a rating form on those.
+ * Only `publish` is accepted. A rating form is never shown to visitors on any
+ * other status (draft, pending, future, private, trash, auto-draft, inherit),
+ * and accepting `private` here would let an unauthenticated caller write rating
+ * meta to restricted content they cannot read.
  *
  * @since 1.7.9
  * @param int $post_id Post ID.
  * @return bool True if the post accepts ratings, false otherwise.
  */
 function bsf_is_rateable_post( $post_id ) {
-	if ( $post_id <= 0 || ! in_array( get_post_status( $post_id ), array( 'publish', 'private' ), true ) ) {
+	if ( $post_id <= 0 || 'publish' !== get_post_status( $post_id ) ) {
 		return false;
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -1182,15 +1182,68 @@ add_filter( 'the_content', 'display_rich_snippet', 90 );
 require_once plugin_dir_path( __FILE__ ) . 'meta-boxes.php';
 /**
  * Get_the_ip.
+ *
+ * Resolves the visitor IP, which is used as the per-visitor rating key.
+ *
+ * `REMOTE_ADDR` is the connecting address and cannot be forged. Forwarded
+ * headers (`X-Forwarded-For` / `Client-IP`) are supplied by the client, so
+ * they are only consulted when `REMOTE_ADDR` is a private or reserved
+ * address — which means the request reached us through a local proxy or CDN
+ * edge rather than directly, and the forwarded header is then the only way to
+ * tell visitors apart. On a directly reachable site the headers are ignored,
+ * so a visitor cannot mint unlimited identities by rotating them.
+ *
+ * Sites with an unusual topology can override the decision with the
+ * `bsf_trust_forwarded_ip` filter. The result is always a valid IP or an
+ * empty string.
+ *
+ * @since 1.7.9 Forwarded headers are no longer trusted unconditionally.
+ * @return string Validated IP address, or an empty string if none could be resolved.
  */
 function get_the_ip() {
-	if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
-		return sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
-	} elseif ( isset( $_SERVER['HTTP_CLIENT_IP'] ) ) {
-		return sanitize_text_field( wp_unslash( $_SERVER['HTTP_CLIENT_IP'] ) );
-	} else {
-		return isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+	$remote = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+	$ip     = filter_var( $remote, FILTER_VALIDATE_IP ) ? $remote : '';
+
+	// A private/reserved connecting address means we sit behind a proxy or CDN.
+	$behind_proxy = '' !== $ip && ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE );
+
+	/**
+	 * Filters whether forwarded IP headers may be trusted.
+	 *
+	 * Defaults to true only when the connecting address is private or reserved.
+	 * Force it to true when a public-facing proxy fronts the site, or to false
+	 * to always key ratings on the connecting address.
+	 *
+	 * @since 1.7.9
+	 * @param bool   $trust_forwarded Whether to honour forwarded IP headers.
+	 * @param string $ip              The validated connecting address.
+	 */
+	if ( apply_filters( 'bsf_trust_forwarded_ip', $behind_proxy, $ip ) ) {
+		$forwarded = '';
+
+		if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+			$forwarded = sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
+		} elseif ( isset( $_SERVER['HTTP_CLIENT_IP'] ) ) {
+			$forwarded = sanitize_text_field( wp_unslash( $_SERVER['HTTP_CLIENT_IP'] ) );
+		}
+
+		if ( '' !== $forwarded ) {
+			/*
+			 * Proxies append to X-Forwarded-For rather than replacing it, so a
+			 * client-supplied value ends up on the LEFT and the address our
+			 * proxy actually saw on the RIGHT. Read the rightmost entry: it is
+			 * the only one the visitor could not have written themselves.
+			 */
+			$chain     = explode( ',', $forwarded );
+			$candidate = trim( end( $chain ) );
+
+			if ( filter_var( $candidate, FILTER_VALIDATE_IP ) ) {
+				$ip = $candidate;
+			}
+		}
 	}
+
+	return filter_var( $ip, FILTER_VALIDATE_IP ) ? $ip : '';
 }
 /**
  * Average_rating.
@@ -1286,16 +1339,22 @@ function add_ajax_library() {
  * Determine whether a post is allowed to receive interactive star ratings.
  *
  * The rating form is only rendered for Product (6), Recipe (7) and Software (8)
- * schema types, so ratings must never be accepted for any other post, an
- * unpublished post, or a non-existent post ID. This prevents unauthenticated
- * callers from writing rating meta to arbitrary posts.
+ * schema types, so ratings must never be accepted for any other post or for a
+ * non-existent post ID. This prevents unauthenticated callers from writing
+ * rating meta to arbitrary posts.
+ *
+ * Both `publish` and `private` are accepted: a private post is published
+ * content with a restricted audience, and the rating form does render for
+ * viewers who are allowed to see it. Every other status — draft, pending,
+ * future, trash, auto-draft, inherit — is rejected, as no visitor is ever
+ * shown a rating form on those.
  *
  * @since 1.7.9
  * @param int $post_id Post ID.
  * @return bool True if the post accepts ratings, false otherwise.
  */
 function bsf_is_rateable_post( $post_id ) {
-	if ( $post_id <= 0 || 'publish' !== get_post_status( $post_id ) ) {
+	if ( $post_id <= 0 || ! in_array( get_post_status( $post_id ), array( 'publish', 'private' ), true ) ) {
 		return false;
 	}
 
@@ -1388,10 +1447,18 @@ function bsf_update_rating() {
 	$existing = get_post_meta( $postid, 'post-rating', false );
 	if ( ! empty( $existing ) && is_array( $existing ) ) {
 		foreach ( $existing as $rating_row ) {
-			if ( isset( $rating_row['user_ip'] ) && $rating_row['user_ip'] === $ip ) {
-				update_post_meta( $postid, 'post-rating', $user_rating, $rating_row );
-				wp_send_json_success( __( 'Ratings updated successfully !', 'rich-snippets' ) );
+			if ( ! isset( $rating_row['user_ip'] ) || $rating_row['user_ip'] !== $ip ) {
+				continue;
 			}
+
+			// update_post_meta() returns false when the write fails and when the
+			// stored value is already identical, so re-submitting the same star
+			// is rejected just as it was before this change.
+			if ( false === update_post_meta( $postid, 'post-rating', $user_rating, $rating_row ) ) {
+				wp_send_json_error( __( 'Error updating your rating', 'rich-snippets' ) );
+			}
+
+			wp_send_json_success( __( 'Ratings updated successfully !', 'rich-snippets' ) );
 		}
 	}
 
@@ -1417,7 +1484,6 @@ function display_rating() {
 		$rating .= '<input type="radio" name="star-review" class="star star-4" value="4" id="bsf-star-4" aria-label="' . esc_attr__( '4 stars', 'rich-snippets' ) . '"/><label for="bsf-star-4" class="bsf-sr-only">' . esc_html__( '4 stars', 'rich-snippets' ) . '</label>';
 		$rating .= '<input type="radio" name="star-review" class="star star-5" value="5" id="bsf-star-5" aria-label="' . esc_attr__( '5 stars', 'rich-snippets' ) . '"/><label for="bsf-star-5" class="bsf-sr-only">' . esc_html__( '5 stars', 'rich-snippets' ) . '</label>';
 		$rating .= '</fieldset>';
-		$rating .= '<input type="hidden" name="ip" value="' . esc_attr( get_the_ip() ) . '" />';
 		$rating .= '<input type="hidden" name="post_id" value="' . $post->ID . '" />';
 		$rating .= '</form>';
 		$rating .= '</div></span>';
@@ -1496,7 +1562,6 @@ function bsf_display_rating( $n ) {
 	4 === $n ? $rating .= ' checked="checked"/>' : $rating .= '/>';
 		$rating        .= '<input type="radio" name="star-review" class="star star-5" value="5" ';
 	5 === $n ? $rating .= ' checked="checked"/>' : $rating .= '/>';
-		$rating        .= '<input type="hidden" name="ip" value="' . get_the_ip() . '" />';
 		$rating        .= '<input type="hidden" name="post_id" value="' . $post->ID . '" />';
 		$rating        .= '</form>';
 		$rating        .= '</div></span>';

--- a/functions.php
+++ b/functions.php
@@ -1283,6 +1283,27 @@ function add_ajax_library() {
 	echo $html; //phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 }
 /**
+ * Determine whether a post is allowed to receive interactive star ratings.
+ *
+ * The rating form is only rendered for Product (6), Recipe (7) and Software (8)
+ * schema types, so ratings must never be accepted for any other post, an
+ * unpublished post, or a non-existent post ID. This prevents unauthenticated
+ * callers from writing rating meta to arbitrary posts.
+ *
+ * @since 1.7.9
+ * @param int $post_id Post ID.
+ * @return bool True if the post accepts ratings, false otherwise.
+ */
+function bsf_is_rateable_post( $post_id ) {
+	if ( $post_id <= 0 || 'publish' !== get_post_status( $post_id ) ) {
+		return false;
+	}
+
+	$schema_type = (string) get_post_meta( $post_id, '_bsf_post_type', true );
+
+	return in_array( $schema_type, array( '6', '7', '8' ), true );
+}
+/**
  * Bsf_add_rating.
  */
 function bsf_add_rating() {
@@ -1292,15 +1313,32 @@ function bsf_add_rating() {
 		return;
 	}
 
-	if ( isset( $_POST['star-review'] ) ) {
-		$stars = intval( $_POST['star-review'] );
-	} else {
-		$stars = 0;
+	$postid = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+
+	// Only accept ratings for published posts that actually render a rating form.
+	if ( ! bsf_is_rateable_post( $postid ) ) {
+		wp_send_json_error( __( 'Invalid rating request.', 'rich-snippets' ) );
 	}
 
-	$ip = sanitize_text_field( wp_unslash( $_POST['ip'] ) );
+	$stars = isset( $_POST['star-review'] ) ? intval( $_POST['star-review'] ) : 0;
 
-	$postid = absint( $_POST['post_id'] );
+	// Ratings are 1-5 stars; reject anything outside that range.
+	if ( $stars < 1 || $stars > 5 ) {
+		wp_send_json_error( __( 'Invalid rating value.', 'rich-snippets' ) );
+	}
+
+	// Derive the visitor IP server-side; never trust a client-supplied value.
+	$ip = get_the_ip();
+
+	// One rating per IP per post: block duplicate and unbounded submissions.
+	$existing = get_post_meta( $postid, 'post-rating', false );
+	if ( ! empty( $existing ) && is_array( $existing ) ) {
+		foreach ( $existing as $rating_row ) {
+			if ( isset( $rating_row['user_ip'] ) && $rating_row['user_ip'] === $ip ) {
+				wp_send_json_error( __( 'You have already rated this item.', 'rich-snippets' ) );
+			}
+		}
+	}
 
 	$user_rating = array(
 		'post_id'     => $postid,
@@ -1322,17 +1360,23 @@ function bsf_update_rating() {
 
 		return;
 	}
-	if ( isset( $_POST['star-review'] ) ) {
-		$stars = intval( $_POST['star-review'] );
-	} else {
-		$stars = 0;
+
+	$postid = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+
+	// Only accept ratings for published posts that actually render a rating form.
+	if ( ! bsf_is_rateable_post( $postid ) ) {
+		wp_send_json_error( __( 'Invalid rating request.', 'rich-snippets' ) );
 	}
 
-	$ip = sanitize_text_field( wp_unslash( $_POST['ip'] ) );
+	$stars = isset( $_POST['star-review'] ) ? intval( $_POST['star-review'] ) : 0;
 
-	$postid = absint( $_POST['post_id'] );
+	// Ratings are 1-5 stars; reject anything outside that range.
+	if ( $stars < 1 || $stars > 5 ) {
+		wp_send_json_error( __( 'Invalid rating value.', 'rich-snippets' ) );
+	}
 
-	$prev_data = get_post_meta( $postid, 'post-rating', true );
+	// Derive the visitor IP server-side; never trust a client-supplied value.
+	$ip = get_the_ip();
 
 	$user_rating = array(
 		'post_id'     => $postid,
@@ -1340,7 +1384,19 @@ function bsf_update_rating() {
 		'user_rating' => $stars,
 	);
 
-	if ( false === update_post_meta( $postid, 'post-rating', $user_rating, $prev_data ) ) {
+	// Update only the rating row that belongs to this IP.
+	$existing = get_post_meta( $postid, 'post-rating', false );
+	if ( ! empty( $existing ) && is_array( $existing ) ) {
+		foreach ( $existing as $rating_row ) {
+			if ( isset( $rating_row['user_ip'] ) && $rating_row['user_ip'] === $ip ) {
+				update_post_meta( $postid, 'post-rating', $user_rating, $rating_row );
+				wp_send_json_success( __( 'Ratings updated successfully !', 'rich-snippets' ) );
+			}
+		}
+	}
+
+	// No existing rating for this IP; store it as a new rating.
+	if ( false === add_post_meta( $postid, 'post-rating', $user_rating ) ) {
 		wp_send_json_error( __( 'Error updating your rating', 'rich-snippets' ) );
 	}
 	wp_send_json_success( __( 'Ratings updated successfully !', 'rich-snippets' ) );

--- a/languages/all-in-one-schemaorg-rich-snippets.pot
+++ b/languages/all-in-one-schemaorg-rich-snippets.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Schema - All In One Schema Rich Snippets 1.7.8\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/all-in-one-schemaorg-rich-snippets\n"
-"POT-Creation-Date: 2026-07-15 05:24:48+00:00\n"
+"POT-Creation-Date: 2026-07-31 09:34:47+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1041,74 +1041,74 @@ msgid "Schema Information"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1312
-#: functions.php:1312
+#: functions.php:1409
 msgid "Error adding your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1314
-#: functions.php:1314
+#: functions.php:1411
 msgid "Ratings added successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1344
-#: functions.php:1344
+#: functions.php:1458 functions.php:1467
 msgid "Error updating your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1346
-#: functions.php:1346
+#: functions.php:1461 functions.php:1469
 msgid "Ratings updated successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1354
-#: functions.php:1354
+#: functions.php:1477
 msgid "Rate this item"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1356
-#: functions.php:1356
+#: functions.php:1479
 msgid "Rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1358
-#: functions.php:1358
+#: functions.php:1481
 msgid "1 star"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1359
-#: functions.php:1359
+#: functions.php:1482
 msgid "2 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1360
-#: functions.php:1360
+#: functions.php:1483
 msgid "3 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1361
-#: functions.php:1361
+#: functions.php:1484
 msgid "4 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1362
-#: functions.php:1362
+#: functions.php:1485
 msgid "5 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1406
-#: functions.php:1406
+#: functions.php:1528
 msgid "All In One Schema Rich Snippets"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1407
-#: functions.php:1407
+#: functions.php:1529
 msgid ""
 "How likely are you to recommend All In One Schema Rich Snippets to your "
 "friends or colleagues?"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1409
-#: functions.php:1409
+#: functions.php:1531
 msgid ""
 "Could you please do us a favor and give us a 5-star rating on Wordpress? It "
 "would help others choose All In One Schema Rich Snippets with confidence. "
@@ -1116,12 +1116,12 @@ msgid ""
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1412
-#: functions.php:1412
+#: functions.php:1534
 msgid "Thank you for your feedback"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1413
-#: functions.php:1413
+#: functions.php:1535
 msgid "We value your input. How can we improve your experience?"
 msgstr ""
 
@@ -2282,6 +2282,18 @@ msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/settings.php:151 settings.php:151
 msgid "Provider telephone number"
+msgstr ""
+
+#: functions.php:1379 functions.php:1427
+msgid "Invalid rating request."
+msgstr ""
+
+#: functions.php:1386 functions.php:1434
+msgid "Invalid rating value."
+msgstr ""
+
+#: functions.php:1397
+msgid "You have already rated this item."
 msgstr ""
 
 #: vendor/wp-cli/core-command/src/Core_Command.php:759

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,9 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 4. Test the post or page URL in Google Rich Snippets Testing
 
 == Changelog ==
+### 1.7.9 ###
+- Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
+
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.
 - Security: Hardened the build toolchain by resolving dependency advisories.

--- a/readme.txt
+++ b/readme.txt
@@ -99,6 +99,8 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 == Changelog ==
 ### 1.7.9 ###
 - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
+- Security: Removed a hidden field from the rating form whose value was output without escaping.
+- Improvement: Ratings are now identified by the connecting IP address rather than client-supplied forwarding headers. Sites behind a reverse proxy or CDN are detected automatically, and the new `bsf_trust_forwarded_ip` filter can override that decision.
 
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.

--- a/readme.txt
+++ b/readme.txt
@@ -100,7 +100,6 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 ### 1.7.9 ###
 - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
 - Security: Removed a hidden field from the rating form whose value was output without escaping.
-- Improvement: Ratings are now identified by the connecting IP address rather than client-supplied forwarding headers. Sites behind a reverse proxy or CDN are detected automatically, and the new `bsf_trust_forwarded_ip` filter can override that decision.
 
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.


### PR DESCRIPTION
## Summary

Hardens the two **unauthenticated** rating AJAX handlers (`bsf_submit_rating` / `bsf_update_rating` in `functions.php`). Before this change they wrote `post-rating` post-meta using a client-supplied `post_id` with no validation, trusted a client-supplied IP, did no server-side dedup, and did not bound the rating value — allowing rating forgery on arbitrary posts and unbounded post-meta writes.

- **Object validation** — new `bsf_is_rateable_post()` gate: only **published** posts whose schema type actually renders a rating form (Product `6`, Recipe `7`, Software `8`) are accepted. Closes the arbitrary / draft / non-existent post-meta write (IDOR).
- **Server-side IP** — the visitor IP is now derived via `get_the_ip()` instead of the posted `ip` field, so the dedup key can't be forged from the request body.
- **One rating per IP per post** — enforced server-side to block duplicate and unbounded submissions.
- **Range check** — rating values outside `1–5` are rejected, preventing aggregate-rating skew.

Scoped, proportionate change — no rework of the rating storage model or IP resolution (see note below).

## Known residual (intentional, out of scope here)

`get_the_ip()` still honours `X-Forwarded-For` / `Client-IP` for proxy/CDN compatibility, so a determined attacker rotating spoofed headers can still register more than one vote on a genuinely-published rateable post. Fully closing this means resolving IP from `REMOTE_ADDR`, which breaks dedup accuracy behind reverse proxies/CDNs — deliberately left for a separate discussion.

## Test plan

Verified end-to-end on a local install (unauthenticated, against `admin-ajax.php`) and with an isolated unit harness on the extracted handlers:

- [x] Legit rating on a published Product stores exactly one row.
- [x] A spoofed `ip` in the POST body is ignored; the server-derived IP is stored.
- [x] A second submission from the same visitor is rejected ("already rated") — no extra row.
- [x] Submissions targeting a draft / non-rateable / non-existent post ID are rejected — no write.
- [x] Out-of-range and zero star values are rejected.
- [x] Invalid nonce is rejected.
- [x] Update handler updates the caller's own row in place; a new IP adds its own row.
- [x] `php -l` clean on `functions.php`.

## Notes

- Adds a `1.7.9` changelog entry in `readme.txt` and `README.md`.
- New helper documented with `@since 1.7.9`.
