### PR TITLE
GIT-253: Report an unchanged settings save as a no-op instead of a failure

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -1005,7 +1005,7 @@ if ( isset( $_POST['setting_submit'] ) ) {
 			$args = false;
 		}
 		update_option( 'bsf_woocom_init_setting', 'done' );
-		$status = update_option( 'bsf_woocom_setting', $args );
+		$status = bsf_save_option( 'bsf_woocom_setting', $args );
 		display_status( $status );
 	}
 }
@@ -1019,7 +1019,7 @@ if ( isset( $_POST['item_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_review', $args );
+		$status = bsf_save_option( 'bsf_review', $args );
 		display_status( $status );
 	}
 }
@@ -1034,7 +1034,7 @@ if ( isset( $_POST['event_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_event', $args );
+		$status = bsf_save_option( 'bsf_event', $args );
 		display_status( $status );
 	}
 }
@@ -1049,7 +1049,7 @@ if ( isset( $_POST['person_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_person', $args );
+		$status = bsf_save_option( 'bsf_person', $args );
 		display_status( $status );
 	}
 }
@@ -1064,7 +1064,7 @@ if ( isset( $_POST['product_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_product', $args );
+		$status = bsf_save_option( 'bsf_product', $args );
 		display_status( $status );
 	}
 }
@@ -1079,7 +1079,7 @@ if ( isset( $_POST['recipe_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_recipe', $args );
+		$status = bsf_save_option( 'bsf_recipe', $args );
 		display_status( $status );
 	}
 }
@@ -1094,7 +1094,7 @@ if ( isset( $_POST['software_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_software', $args );
+		$status = bsf_save_option( 'bsf_software', $args );
 		display_status( $status );
 	}
 }
@@ -1109,7 +1109,7 @@ if ( isset( $_POST['video_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_video', $args );
+		$status = bsf_save_option( 'bsf_video', $args );
 		display_status( $status );
 	}
 }
@@ -1124,7 +1124,7 @@ if ( isset( $_POST['article_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_article', $args );
+		$status = bsf_save_option( 'bsf_article', $args );
 		display_status( $status );
 	}
 }
@@ -1139,17 +1139,23 @@ if ( isset( $_POST['service_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_service', $args );
+		$status = bsf_save_option( 'bsf_service', $args );
 		display_status( $status );
 	}
 }
 /**
  * Display status.
  *
- * @param  string $status .
+ * Accepts the return value of bsf_save_option(): 'saved', 'unchanged', or
+ * false. A plain truthy value is still treated as a successful save so any
+ * existing caller keeps working.
+ *
+ * @param  string|bool $status .
  */
 function display_status( $status ) {
-	if ( $status ) {
+	if ( 'unchanged' === $status ) {
+		echo '<div class="notice notice-info"><p>' . esc_html__( 'No changes to save.', 'rich-snippets' ) . '</p></div>';
+	} elseif ( $status ) {
 		echo '<div class="updated"><p>' . esc_html__( 'Success! Your changes were successfully saved!', 'rich-snippets' ) . '</p></div>';
 	} else {
 		echo '<div class="error"><p>' . esc_html__( 'Sorry, Your changes are not saved!', 'rich-snippets' ) . '</p></div>';

--- a/functions.php
+++ b/functions.php
@@ -1181,6 +1181,29 @@ add_filter( 'the_content', 'display_rich_snippet', 90 );
 
 require_once plugin_dir_path( __FILE__ ) . 'meta-boxes.php';
 /**
+ * Save a settings option and report what actually happened.
+ *
+ * update_option() returns false both when the write fails and when the stored
+ * value is already identical to the new one, so its return value alone cannot
+ * tell a genuine failure from a submission that had nothing to change.
+ * Re-reading the option separates the two so each case can be reported
+ * accurately instead of showing a failure notice for an unchanged save.
+ *
+ * @since 1.7.9
+ * @param string $option Option name.
+ * @param mixed  $args   Value to store.
+ * @return string|false 'saved' when written, 'unchanged' when it already held
+ *                      this value, false when the option does not hold it.
+ */
+function bsf_save_option( $option, $args ) {
+	if ( update_option( $option, $args ) ) {
+		return 'saved';
+	}
+
+	// Nothing was written: either it already matched, or the write failed.
+	return get_option( $option ) === $args ? 'unchanged' : false;
+}
+/**
  * Get_the_ip.
  */
 function get_the_ip() {

--- a/functions.php
+++ b/functions.php
@@ -1318,7 +1318,7 @@ function add_ajax_library() {
  * and accepting `private` here would let an unauthenticated caller write rating
  * meta to restricted content they cannot read.
  *
- * @since 1.7.9
+ * @since x.x.x
  * @param int $post_id Post ID.
  * @return bool True if the post accepts ratings, false otherwise.
  */

--- a/functions.php
+++ b/functions.php
@@ -1183,13 +1183,13 @@ require_once plugin_dir_path( __FILE__ ) . 'meta-boxes.php';
 /**
  * Save a settings option and report what actually happened.
  *
- * update_option() returns false both when the write fails and when the stored
- * value is already identical to the new one, so its return value alone cannot
- * tell a genuine failure from a submission that had nothing to change.
- * Re-reading the option separates the two so each case can be reported
- * accurately instead of showing a failure notice for an unchanged save.
+ * Both a failed write and an unchanged value make update_option() return false,
+ * so its return value alone cannot tell a genuine failure from a submission
+ * that had nothing to change. Re-reading the option separates the two, so each
+ * case can be reported accurately instead of showing a failure notice for an
+ * unchanged save.
  *
- * @since 1.7.9
+ * @since x.x.x
  * @param string $option Option name.
  * @param mixed  $args   Value to store.
  * @return string|false 'saved' when written, 'unchanged' when it already held

--- a/functions.php
+++ b/functions.php
@@ -1189,6 +1189,10 @@ require_once plugin_dir_path( __FILE__ ) . 'meta-boxes.php';
  * case can be reported accurately instead of showing a failure notice for an
  * unchanged save.
  *
+ * A boolean that is already stored is reported as unchanged rather than as a
+ * failure. An option that does not exist yet reads back as false, so saving
+ * false over it is also reported as unchanged, since nothing needed writing.
+ *
  * @since x.x.x
  * @param string $option Option name.
  * @param mixed  $args   Value to store.
@@ -1201,7 +1205,24 @@ function bsf_save_option( $option, $args ) {
 	}
 
 	// Nothing was written: either it already matched, or the write failed.
-	return get_option( $option ) === $args ? 'unchanged' : false;
+	$stored = get_option( $option );
+
+	if ( $stored === $args ) {
+		return 'unchanged';
+	}
+
+	/*
+	 * Scalars do not keep their type in the options table: true is read back as
+	 * '1' and false as an empty string. Comparing the submitted value strictly
+	 * against the stored one would therefore report a failure for a setting
+	 * that is already correct, so compare the stored form for scalars. Arrays
+	 * keep their types and are covered by the strict check above.
+	 */
+	if ( is_scalar( $args ) && is_scalar( $stored ) ) {
+		return (string) $stored === (string) $args ? 'unchanged' : false;
+	}
+
+	return false;
 }
 /**
  * Get_the_ip.

--- a/index.php
+++ b/index.php
@@ -393,7 +393,7 @@ if ( ! class_exists( 'RichSnippets' ) ) {
 						'snippet_title_color' => $title_color,
 						'snippet_box_color'   => $box_color,
 					);
-					$color_saved = bsf_save_option( 'bsf_custom', $color_opt );
+					$color_saved      = bsf_save_option( 'bsf_custom', $color_opt );
 
 					if ( 'unchanged' === $color_saved ) {
 						wp_send_json_success( __( 'No changes to save.', 'rich-snippets' ) );

--- a/index.php
+++ b/index.php
@@ -393,7 +393,11 @@ if ( ! class_exists( 'RichSnippets' ) ) {
 						'snippet_title_color' => $title_color,
 						'snippet_box_color'   => $box_color,
 					);
-					if ( update_option( 'bsf_custom', $color_opt ) ) {
+					$color_saved = bsf_save_option( 'bsf_custom', $color_opt );
+
+					if ( 'unchanged' === $color_saved ) {
+						wp_send_json_success( __( 'No changes to save.', 'rich-snippets' ) );
+					} elseif ( $color_saved ) {
 						wp_send_json_success( __( 'Settings saved !', 'rich-snippets' ) );
 					} else {
 						wp_send_json_error( __( 'Error occured. Settings were not saved !', 'rich-snippets' ) );

--- a/languages/all-in-one-schemaorg-rich-snippets.pot
+++ b/languages/all-in-one-schemaorg-rich-snippets.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Schema - All In One Schema Rich Snippets 1.7.8\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/all-in-one-schemaorg-rich-snippets\n"
-"POT-Creation-Date: 2026-07-31 09:34:47+00:00\n"
+"POT-Creation-Date: 2026-08-13 08:07:19+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -233,7 +233,7 @@ msgstr ""
 #: admin/index.php:745 admin/index.php:752 admin/index.php:759
 #: admin/index.php:768 admin/index.php:775 admin/index.php:784
 #: admin/index.php:804 admin/index.php:853 admin/index.php:878
-#: admin/index.php:1294
+#: admin/index.php:1300
 msgid "Toggle panel: Frontend Options"
 msgstr ""
 
@@ -980,54 +980,54 @@ msgid "Sorry, your nonce did not verify."
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1153
-#: admin/index.php:1153
+#: admin/index.php:1159
 msgid "Success! Your changes were successfully saved!"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1155
-#: admin/index.php:1155
+#: admin/index.php:1161
 msgid "Sorry, Your changes are not saved!"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1295
-#: admin/index.php:1295
+#: admin/index.php:1301
 msgid "Get in touch with the Plugin Developers"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1299
-#: admin/index.php:1299
+#: admin/index.php:1305
 msgid ""
 "Just fill out the form below and your message will be emailed to the Plugin "
 "Developers."
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1301
-#: admin/index.php:1301
+#: admin/index.php:1307
 msgid "Your Name:"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1303
-#: admin/index.php:1303
+#: admin/index.php:1309
 msgid "Your Email:"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1305
-#: admin/index.php:1305
+#: admin/index.php:1311
 msgid "Reference URL:"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1307
-#: admin/index.php:1307
+#: admin/index.php:1313
 msgid "Subject:"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1318
-#: admin/index.php:1318
+#: admin/index.php:1324
 msgid "Your Query in Brief:"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1322
-#: admin/index.php:1322
+#: admin/index.php:1328
 msgid "Submit Request"
 msgstr ""
 
@@ -1041,74 +1041,74 @@ msgid "Schema Information"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1312
-#: functions.php:1409
+#: functions.php:1378
 msgid "Error adding your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1314
-#: functions.php:1411
+#: functions.php:1380
 msgid "Ratings added successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1344
-#: functions.php:1458 functions.php:1467
+#: functions.php:1427 functions.php:1436
 msgid "Error updating your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1346
-#: functions.php:1461 functions.php:1469
+#: functions.php:1430 functions.php:1438
 msgid "Ratings updated successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1354
-#: functions.php:1477
+#: functions.php:1446
 msgid "Rate this item"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1356
-#: functions.php:1479
+#: functions.php:1448
 msgid "Rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1358
-#: functions.php:1481
+#: functions.php:1450
 msgid "1 star"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1359
-#: functions.php:1482
+#: functions.php:1451
 msgid "2 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1360
-#: functions.php:1483
+#: functions.php:1452
 msgid "3 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1361
-#: functions.php:1484
+#: functions.php:1453
 msgid "4 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1362
-#: functions.php:1485
+#: functions.php:1454
 msgid "5 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1406
-#: functions.php:1528
+#: functions.php:1497
 msgid "All In One Schema Rich Snippets"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1407
-#: functions.php:1529
+#: functions.php:1498
 msgid ""
 "How likely are you to recommend All In One Schema Rich Snippets to your "
 "friends or colleagues?"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1409
-#: functions.php:1531
+#: functions.php:1500
 msgid ""
 "Could you please do us a favor and give us a 5-star rating on Wordpress? It "
 "would help others choose All In One Schema Rich Snippets with confidence. "
@@ -1116,12 +1116,12 @@ msgid ""
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1412
-#: functions.php:1534
+#: functions.php:1503
 msgid "Thank you for your feedback"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1413
-#: functions.php:1535
+#: functions.php:1504
 msgid "We value your input. How can we improve your experience?"
 msgstr ""
 
@@ -1153,11 +1153,11 @@ msgstr ""
 msgid "Something went wrong!"
 msgstr ""
 
-#: .claude/worktrees/dazzling-shamir-f1f2e3/index.php:397 index.php:397
+#: .claude/worktrees/dazzling-shamir-f1f2e3/index.php:397 index.php:401
 msgid "Settings saved !"
 msgstr ""
 
-#: .claude/worktrees/dazzling-shamir-f1f2e3/index.php:399 index.php:399
+#: .claude/worktrees/dazzling-shamir-f1f2e3/index.php:399 index.php:403
 msgid "Error occured. Settings were not saved !"
 msgstr ""
 
@@ -2284,15 +2284,19 @@ msgstr ""
 msgid "Provider telephone number"
 msgstr ""
 
-#: functions.php:1379 functions.php:1427
+#: admin/index.php:1157 index.php:399
+msgid "No changes to save."
+msgstr ""
+
+#: functions.php:1348 functions.php:1396
 msgid "Invalid rating request."
 msgstr ""
 
-#: functions.php:1386 functions.php:1434
+#: functions.php:1355 functions.php:1403
 msgid "Invalid rating value."
 msgstr ""
 
-#: functions.php:1397
+#: functions.php:1366
 msgid "You have already rated this item."
 msgstr ""
 


### PR DESCRIPTION
Fixes #253

## Summary

- Every settings form on **Rich Snippets → Dashboard** showed **"Sorry, Your changes are not saved!"** after clicking Update without editing a field. Nothing had failed and the settings were intact.
- Root cause: `update_option()` returns `false` both when the write fails **and** when the stored value already matches the submitted one. The handlers treated every `false` as a failure.
- Adds `bsf_save_option()`, which re-reads the option when `update_option()` returns `false` and separates the two cases it conflates.
- `display_status()` gains a third, neutral notice for the unchanged case. A plain truthy value is still treated as a successful save, so any existing caller keeps working.
- Wired into the nine schema forms and the WooCommerce toggle in `admin/index.php`, and into the `submit_color` AJAX handler in `index.php`, which had the same problem (**"Error occured. Settings were not saved !"** on re-saving identical colours).

| Situation | Return | Notice |
|---|---|---|
| Value written | `saved` | Success! Your changes were successfully saved! |
| Already held this value | `unchanged` | No changes to save. |
| Option does not hold the value | `false` | Sorry, Your changes are not saved! |

### Why the helper lives in `functions.php`

`admin/index.php` is only `require_once`d inside `register_custom_menu_page()` on the `admin_menu` hook, which does not fire during `admin-ajax.php`. Defining the helper there and calling it from `submit_color` would be a fatal error. `functions.php` is required unconditionally.

### Note for reviewers

Failure is `false` rather than a `'failed'` string, because any non-empty string is truthy in PHP and would fall through to the success branch. `display_status()` therefore checks `'unchanged' === $status` before the truthy check.

## Test plan

Verified against a real WordPress install by driving the same functions the handlers call.

- [x] Unchanged save on all nine schema options returns `unchanged` and shows the neutral notice.
- [x] A genuine change returns `saved` and stores the new value.
- [x] Saving the same value immediately afterwards returns `unchanged`.
- [x] A diverging stored value returns `false`, so real failures still show the error notice.
- [x] WooCommerce boolean toggle: unchanged saves in both states report `unchanged`, real flips report `saved`.

**Correction:** an earlier revision of this test plan claimed the WooCommerce boolean was verified. It was not. That check ran `update_option()` and `get_option()` in the *same* request, where the option cache holds the exact PHP value just written and hides the serialization round-trip. Real saves happen in fresh requests where the cache is loaded from the database as `'1'`/`''`, and the toggle still produced the failure notice in both states. Caught in review, fixed in 4c3c0f1, and re-verified through the real admin form as a logged-in administrator:

```
BEFORE                                        AFTER
  ON  (already on)  -> Sorry, ...not saved!     ON  (already on)  -> No changes to save.
  ON  (again)       -> Sorry, ...not saved!     ON  (again)       -> No changes to save.
  OFF (real change) -> Success!                 OFF (real change) -> Success!
  OFF (again)       -> Sorry, ...not saved!     OFF (again)       -> No changes to save.
  ON  (real change) -> Success!                 ON  (real change) -> Success!
```

- [x] Schema form driven end to end through the admin UI: real change reports `saved`, resubmitting the same values reports `unchanged`.
- [x] Stored representation unchanged (`'1'` / `''`), so both consumers gating on `empty( $woo_settings )` read exactly as before. No migration.
- [x] Helper resolves in a non-dashboard request, covering the AJAX path.
- [x] Rating regression suite unaffected: 26/26 over HTTP against `admin-ajax.php`.
- [x] `php -l` clean on `index.php`, `functions.php`, `admin/index.php`.

PHPCS passes in CI. Locally the full run needs PHP 8.2 (Local's bundled binary) rather than the system PHP, and still aborts inside WPCS 2.3.0 on `trim(): Passing null`; scoping to individual sniffs reproduces CI exactly and is clean. `composer phpstan` could not be run at all: it aborts during bootstrap with `Cannot redeclare WP_CLI\Dispatcher\CompositeCommand` from `tests/php/stubs/aiosrs-stubs.php`, reproduced on files this branch does not touch.

## Notes

- No version bump.
- Translation template regenerated with `grunt i18n` for the new string.
- #254 fixes the same class of bug in the rating update handler. Both branches regenerate the `.pot`; whichever merges second will most likely need it regenerated rather than hand-resolved.
