### PR TITLE
GIT-254: Distinguish a repeated identical rating from a failed update

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1295,7 +1295,7 @@ function add_ajax_library() {
  * and accepting `private` here would let an unauthenticated caller write rating
  * meta to restricted content they cannot read.
  *
- * @since 1.7.9
+ * @since x.x.x
  * @param int $post_id Post ID.
  * @return bool True if the post accepts ratings, false otherwise.
  */

--- a/functions.php
+++ b/functions.php
@@ -1397,9 +1397,14 @@ function bsf_update_rating() {
 				continue;
 			}
 
-			// update_post_meta() returns false when the write fails and when the
-			// stored value is already identical, so re-submitting the same star
-			// is rejected just as it was before this change.
+			// Re-submitting the star already on record changes nothing. Report it
+			// separately, because update_post_meta() returns false both for an
+			// unchanged value and for a failed write, and telling the visitor
+			// their rating errored would be misleading.
+			if ( isset( $rating_row['user_rating'] ) && (int) $rating_row['user_rating'] === $stars ) {
+				wp_send_json_error( __( 'You have already given this rating.', 'rich-snippets' ) );
+			}
+
 			if ( false === update_post_meta( $postid, 'post-rating', $user_rating, $rating_row ) ) {
 				wp_send_json_error( __( 'Error updating your rating', 'rich-snippets' ) );
 			}

--- a/languages/all-in-one-schemaorg-rich-snippets.pot
+++ b/languages/all-in-one-schemaorg-rich-snippets.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Schema - All In One Schema Rich Snippets 1.7.8\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/all-in-one-schemaorg-rich-snippets\n"
-"POT-Creation-Date: 2026-08-13 08:10:10+00:00\n"
+"POT-Creation-Date: 2026-08-14 05:29:34+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1041,74 +1041,74 @@ msgid "Schema Information"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1312
-#: functions.php:1378
+#: functions.php:1399
 msgid "Error adding your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1314
-#: functions.php:1380
+#: functions.php:1401
 msgid "Ratings added successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1344
-#: functions.php:1427 functions.php:1436
+#: functions.php:1453 functions.php:1462
 msgid "Error updating your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1346
-#: functions.php:1430 functions.php:1438
+#: functions.php:1456 functions.php:1464
 msgid "Ratings updated successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1354
-#: functions.php:1446
+#: functions.php:1472
 msgid "Rate this item"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1356
-#: functions.php:1448
+#: functions.php:1474
 msgid "Rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1358
-#: functions.php:1450
+#: functions.php:1476
 msgid "1 star"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1359
-#: functions.php:1451
+#: functions.php:1477
 msgid "2 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1360
-#: functions.php:1452
+#: functions.php:1478
 msgid "3 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1361
-#: functions.php:1453
+#: functions.php:1479
 msgid "4 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1362
-#: functions.php:1454
+#: functions.php:1480
 msgid "5 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1406
-#: functions.php:1497
+#: functions.php:1523
 msgid "All In One Schema Rich Snippets"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1407
-#: functions.php:1498
+#: functions.php:1524
 msgid ""
 "How likely are you to recommend All In One Schema Rich Snippets to your "
 "friends or colleagues?"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1409
-#: functions.php:1500
+#: functions.php:1526
 msgid ""
 "Could you please do us a favor and give us a 5-star rating on Wordpress? It "
 "would help others choose All In One Schema Rich Snippets with confidence. "
@@ -1116,12 +1116,12 @@ msgid ""
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1412
-#: functions.php:1503
+#: functions.php:1529
 msgid "Thank you for your feedback"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1413
-#: functions.php:1504
+#: functions.php:1530
 msgid "We value your input. How can we improve your experience?"
 msgstr ""
 
@@ -2288,19 +2288,19 @@ msgstr ""
 msgid "No changes to save."
 msgstr ""
 
-#: functions.php:1348 functions.php:1396
+#: functions.php:1369 functions.php:1417
 msgid "Invalid rating request."
 msgstr ""
 
-#: functions.php:1355 functions.php:1403
+#: functions.php:1376 functions.php:1424
 msgid "Invalid rating value."
 msgstr ""
 
-#: functions.php:1366
+#: functions.php:1387
 msgid "You have already rated this item."
 msgstr ""
 
-#: functions.php:1405
+#: functions.php:1449
 msgid "You have already given this rating."
 msgstr ""
 

--- a/languages/all-in-one-schemaorg-rich-snippets.pot
+++ b/languages/all-in-one-schemaorg-rich-snippets.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Schema - All In One Schema Rich Snippets 1.7.8\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/all-in-one-schemaorg-rich-snippets\n"
-"POT-Creation-Date: 2026-07-31 09:34:47+00:00\n"
+"POT-Creation-Date: 2026-08-13 08:10:10+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1041,74 +1041,74 @@ msgid "Schema Information"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1312
-#: functions.php:1409
+#: functions.php:1355
 msgid "Error adding your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1314
-#: functions.php:1411
+#: functions.php:1357
 msgid "Ratings added successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1344
-#: functions.php:1458 functions.php:1467
+#: functions.php:1409 functions.php:1418
 msgid "Error updating your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1346
-#: functions.php:1461 functions.php:1469
+#: functions.php:1412 functions.php:1420
 msgid "Ratings updated successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1354
-#: functions.php:1477
+#: functions.php:1428
 msgid "Rate this item"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1356
-#: functions.php:1479
+#: functions.php:1430
 msgid "Rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1358
-#: functions.php:1481
+#: functions.php:1432
 msgid "1 star"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1359
-#: functions.php:1482
+#: functions.php:1433
 msgid "2 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1360
-#: functions.php:1483
+#: functions.php:1434
 msgid "3 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1361
-#: functions.php:1484
+#: functions.php:1435
 msgid "4 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1362
-#: functions.php:1485
+#: functions.php:1436
 msgid "5 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1406
-#: functions.php:1528
+#: functions.php:1479
 msgid "All In One Schema Rich Snippets"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1407
-#: functions.php:1529
+#: functions.php:1480
 msgid ""
 "How likely are you to recommend All In One Schema Rich Snippets to your "
 "friends or colleagues?"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1409
-#: functions.php:1531
+#: functions.php:1482
 msgid ""
 "Could you please do us a favor and give us a 5-star rating on Wordpress? It "
 "would help others choose All In One Schema Rich Snippets with confidence. "
@@ -1116,12 +1116,12 @@ msgid ""
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1412
-#: functions.php:1534
+#: functions.php:1485
 msgid "Thank you for your feedback"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1413
-#: functions.php:1535
+#: functions.php:1486
 msgid "We value your input. How can we improve your experience?"
 msgstr ""
 
@@ -2284,16 +2284,20 @@ msgstr ""
 msgid "Provider telephone number"
 msgstr ""
 
-#: functions.php:1379 functions.php:1427
+#: functions.php:1325 functions.php:1373
 msgid "Invalid rating request."
 msgstr ""
 
-#: functions.php:1386 functions.php:1434
+#: functions.php:1332 functions.php:1380
 msgid "Invalid rating value."
 msgstr ""
 
-#: functions.php:1397
+#: functions.php:1343
 msgid "You have already rated this item."
+msgstr ""
+
+#: functions.php:1405
+msgid "You have already given this rating."
 msgstr ""
 
 #: vendor/wp-cli/core-command/src/Core_Command.php:759


### PR DESCRIPTION
Fixes #254

## Summary

- Re-selecting the star already on record showed **"Error updating your rating"**, which reads as a failure even though nothing went wrong and the stored rating was already the value the visitor asked for.
- Root cause: `update_post_meta()` returns `false` both when the write fails **and** when the stored value is already identical. `bsf_update_rating()` treated every `false` as a failure.
- Detects the unchanged case before writing and reports it as **"You have already given this rating."**, leaving the existing message for a genuine write failure.

| Action | Response |
|---|---|
| Same star re-submitted | `{"success":false,"data":"You have already given this rating."}` |
| Different star | `{"success":true,"data":"Ratings updated successfully !"}` |
| Genuine write failure | `{"success":false,"data":"Error updating your rating"}` |

Row count is unchanged in every case: the update path never adds a row.

## Test plan

Verified end to end over HTTP against `admin-ajax.php` on a real install, unauthenticated.

- [x] Re-submitting the same star returns the new message; the stored row is untouched.
- [x] Choosing a different star still updates in place and reports success.
- [x] Returning to a previous star reports success.
- [x] A genuine write failure still returns "Error updating your rating", proven by injecting a short-circuit on the `update_post_metadata` filter.
- [x] With writes forced to fail, the unchanged case is still reported distinctly rather than as an error.
- [x] Update never adds a row in any of the above.
- [x] Full rating regression suite: 26/26, covering the post-validation gates, the 1-5 range bound, nonce rejection, duplicate-add rejection, and the removed hidden field.
- [x] `php -l` clean on `functions.php`.
- [x] Frontend confirmed not to branch on `response.success`: both rating handlers share one callback that alerts `response.data` and reloads, so the visitor sees the message text with no error styling.

PHPCS passes in CI. Locally the full run needs PHP 8.2 (Local's bundled binary) rather than the system PHP, and still aborts inside WPCS 2.3.0 on `trim(): Passing null`; scoping to individual sniffs reproduces CI exactly and is clean. `composer phpstan` could not be run at all: it aborts during bootstrap with `Cannot redeclare WP_CLI\Dispatcher\CompositeCommand` from `tests/php/stubs/aiosrs-stubs.php`, reproduced on files this branch does not touch.

## Notes

- No version bump.
- Translation template regenerated with `grunt i18n` for the new string.
- #253 fixes the same class of bug on the settings screens, where `update_option()` behaves identically. Both branches regenerate the `.pot`; whichever merges second will most likely need it regenerated rather than hand-resolved.
