### PR TITLE
Release: v1.7.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,9 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
   - Improvement: Compatibility with WordPress 7.1.
   - Fix: Saving a settings form without changes now shows a clear "No changes to save" notice instead of a false error.
   - Fix: Re-submitting the same star rating now reports it was already given instead of showing an update error.
-  - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting
-  out-of-range rating values.
+  - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
   - Security: Removed a hidden field from the rating form whose value was output without escaping.
-  
+
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.
 - Security: Hardened the build toolchain by resolving dependency advisories.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** schema markup, rich snippets, wordpress seo, structured data, google search  
 **Requires at least:** 3.7  
 **Tested up to:** 7.1  
-**Stable tag:** 1.7.8  
+**Stable tag:** 1.7.9  
 **Requires PHP:** 7.4  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
@@ -98,9 +98,13 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 
 ## Changelog ##
 ### 1.7.9 ###
-- Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
-- Security: Removed a hidden field from the rating form whose value was output without escaping.
-
+  - Improvement: Compatibility with WordPress 7.1.
+  - Fix: Saving a settings form without changes now shows a clear "No changes to save" notice instead of a false error.
+  - Fix: Re-submitting the same star rating now reports it was already given instead of showing an update error.
+  - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting
+  out-of-range rating values.
+  - Security: Removed a hidden field from the rating form whose value was output without escaping.
+  
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.
 - Security: Hardened the build toolchain by resolving dependency advisories.

--- a/index.php
+++ b/index.php
@@ -5,7 +5,7 @@
  * Author: Brainstorm Force
  * Author URI: https://www.brainstormforce.com
  * Description: Welcome to the Schema - All In One Schema Rich Snippets! You can now easily add schema markup on various * pages and posts of your website. Implement schema types such as Review, Events, Recipes, Article, Products, Services * *etc.
- * Version: 1.7.8
+ * Version: 1.7.9
  * Text Domain: rich-snippets
  * License: GPL2
  *
@@ -81,7 +81,7 @@ if ( ! class_exists( 'RichSnippets' ) ) {
 			define( 'AIOSRS_PRO_BASE', plugin_basename( AIOSRS_PRO_FILE ) );
 			define( 'AIOSRS_PRO_DIR', plugin_dir_path( AIOSRS_PRO_FILE ) );
 			define( 'AIOSRS_PRO_URI', plugins_url( '/', AIOSRS_PRO_FILE ) );
-			define( 'AIOSRS_PRO_VER', '1.7.8' );
+			define( 'AIOSRS_PRO_VER', '1.7.9' );
 		}
 
 		/**
@@ -486,7 +486,7 @@ $bsf_analytics->set_entity(
 					'id'                => 'deactivation-survey-all-in-one-schemaorg-rich-snippets', // 'deactivation-survey-<your-plugin-slug>'
 					'popup_logo'        => esc_url( plugins_url( 'admin/images/icon_32.png', __FILE__ ) ),
 					'plugin_slug'       => 'all-in-one-schemaorg-rich-snippets',
-					'plugin_version'    => '1.7.8',
+					'plugin_version'    => '1.7.9',
 					'popup_title'       => 'Quick Feedback',
 					'support_url'       => 'https://wpschema.com/contact/',
 					'popup_description' => 'If you have a moment, please share why you are deactivating All In One Schema Rich Snippets:',

--- a/languages/all-in-one-schemaorg-rich-snippets.pot
+++ b/languages/all-in-one-schemaorg-rich-snippets.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the GPL2.
 msgid ""
 msgstr ""
-"Project-Id-Version: Schema - All In One Schema Rich Snippets 1.7.8\n"
+"Project-Id-Version: Schema - All In One Schema Rich Snippets 1.7.9\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/all-in-one-schemaorg-rich-snippets\n"
-"POT-Creation-Date: 2026-08-14 05:29:34+00:00\n"
+"POT-Creation-Date: 2026-08-14 05:37:06+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "all-in-one-schemaorg-rich-snippets",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "main": "Gruntfile.js",
   "author": "Brainstorm Force",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -101,10 +101,9 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
   - Improvement: Compatibility with WordPress 7.1.
   - Fix: Saving a settings form without changes now shows a clear "No changes to save" notice instead of a false error.
   - Fix: Re-submitting the same star rating now reports it was already given instead of showing an update error.
-  - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting
-  out-of-range rating values.
+  - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
   - Security: Removed a hidden field from the rating form whose value was output without escaping.
-  
+
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.
 - Security: Hardened the build toolchain by resolving dependency advisories.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Tags: schema markup, rich snippets, wordpress seo, structured data, google search
 Requires at least: 3.7
 Tested up to: 7.1
-Stable tag: 1.7.8
+Stable tag: 1.7.9
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -98,9 +98,13 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 
 == Changelog ==
 ### 1.7.9 ###
-- Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
-- Security: Removed a hidden field from the rating form whose value was output without escaping.
-
+  - Improvement: Compatibility with WordPress 7.1.
+  - Fix: Saving a settings form without changes now shows a clear "No changes to save" notice instead of a false error.
+  - Fix: Re-submitting the same star rating now reports it was already given instead of showing an update error.
+  - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting
+  out-of-range rating values.
+  - Security: Removed a hidden field from the rating form whose value was output without escaping.
+  
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.
 - Security: Hardened the build toolchain by resolving dependency advisories.


### PR DESCRIPTION
## Summary

Release branch for **v1.7.9**. Bumps the plugin version, refreshes the `.pot`, and finalizes the changelog. Bundles the changes already merged into this cycle:

- **Improvement:** WordPress 7.1 compatibility (version headers / tested-up-to).
- **Security:** Hardened the post rating handlers against IDOR and abuse — validates the rated post (published + rateable schema type only), derives the visitor IP server-side, enforces one rating per visitor, and rejects out-of-range values.
- **Security:** Removed the unescaped hidden `ip` field from the rating form.
- **Fix:** Saving a settings form with no changes now shows a "No changes to save" notice instead of a false error (new `bsf_save_option()` helper).
- **Fix:** Re-submitting the same star rating now reports it was already given instead of an update error.

## Test plan

- [ ] Rate a Product/Recipe/Software post as a visitor — rating saves once; a second attempt from the same IP is blocked.
- [ ] Attempt a rating on a non-rateable / unpublished post ID — rejected with "Invalid rating request".
- [ ] Submit a settings tab with no changes — shows "No changes to save", not an error.
- [ ] Re-submit the same star value — shows "already given this rating".
- [ ] Confirm plugin header, `readme.txt`, and `README.md` all read 1.7.9.
