### PR TITLE
Build version 1.7.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 ## Changelog ##
 ### 1.7.9 ###
 - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
+- Security: Removed a hidden field from the rating form whose value was output without escaping.
+- Improvement: Ratings are now identified by the connecting IP address rather than client-supplied forwarding headers. Sites behind a reverse proxy or CDN are detected automatically, and the new `bsf_trust_forwarded_ip` filter can override that decision.
 
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.

--- a/README.md
+++ b/README.md
@@ -101,10 +101,9 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
   - Improvement: Compatibility with WordPress 7.1.
   - Fix: Saving a settings form without changes now shows a clear "No changes to save" notice instead of a false error.
   - Fix: Re-submitting the same star rating now reports it was already given instead of showing an update error.
-  - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting
-  out-of-range rating values.
+  - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
   - Security: Removed a hidden field from the rating form whose value was output without escaping.
-  
+
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.
 - Security: Hardened the build toolchain by resolving dependency advisories.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** schema markup, rich snippets, wordpress seo, structured data, google search  
 **Requires at least:** 3.7  
 **Tested up to:** 7.1  
-**Stable tag:** 1.7.8  
+**Stable tag:** 1.7.9  
 **Requires PHP:** 7.4  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
@@ -98,9 +98,13 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 
 ## Changelog ##
 ### 1.7.9 ###
-- Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
-- Security: Removed a hidden field from the rating form whose value was output without escaping.
-
+  - Improvement: Compatibility with WordPress 7.1.
+  - Fix: Saving a settings form without changes now shows a clear "No changes to save" notice instead of a false error.
+  - Fix: Re-submitting the same star rating now reports it was already given instead of showing an update error.
+  - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting
+  out-of-range rating values.
+  - Security: Removed a hidden field from the rating form whose value was output without escaping.
+  
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.
 - Security: Hardened the build toolchain by resolving dependency advisories.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Donate link:** https://www.paypal.me/BrainstormForce  
 **Tags:** schema markup, rich snippets, wordpress seo, structured data, google search  
 **Requires at least:** 3.7  
-**Tested up to:** 7.0  
+**Tested up to:** 7.1  
 **Stable tag:** 1.7.8  
 **Requires PHP:** 7.4  
 **License:** GPLv2 or later  

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 4. Test the post or page URL in Google Rich Snippets Testing
 
 ## Changelog ##
+### 1.7.9 ###
+- Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
+
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.
 - Security: Hardened the build toolchain by resolving dependency advisories.

--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 
 ## Changelog ##
 ### 1.7.9 ###
-  - Improvement: Compatibility with WordPress 7.1.
-  - Fix: Saving a settings form without changes now shows a clear "No changes to save" notice instead of a false error.
-  - Fix: Re-submitting the same star rating now reports it was already given instead of showing an update error.
-  - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
-  - Security: Removed a hidden field from the rating form whose value was output without escaping.
+- Improvement: Compatibility with WordPress 7.1.
+- Fix: Saving a settings form without changes now shows a clear "No changes to save" notice instead of a false error.
+- Fix: Re-submitting the same star rating now reports it was already given instead of showing an update error.
+- Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
+- Security: Removed a hidden field from the rating form whose value was output without escaping.
 
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 ### 1.7.9 ###
 - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
 - Security: Removed a hidden field from the rating form whose value was output without escaping.
-- Improvement: Ratings are now identified by the connecting IP address rather than client-supplied forwarding headers. Sites behind a reverse proxy or CDN are detected automatically, and the new `bsf_trust_forwarded_ip` filter can override that decision.
 
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.

--- a/admin/index.php
+++ b/admin/index.php
@@ -1005,7 +1005,7 @@ if ( isset( $_POST['setting_submit'] ) ) {
 			$args = false;
 		}
 		update_option( 'bsf_woocom_init_setting', 'done' );
-		$status = update_option( 'bsf_woocom_setting', $args );
+		$status = bsf_save_option( 'bsf_woocom_setting', $args );
 		display_status( $status );
 	}
 }
@@ -1019,7 +1019,7 @@ if ( isset( $_POST['item_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_review', $args );
+		$status = bsf_save_option( 'bsf_review', $args );
 		display_status( $status );
 	}
 }
@@ -1034,7 +1034,7 @@ if ( isset( $_POST['event_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_event', $args );
+		$status = bsf_save_option( 'bsf_event', $args );
 		display_status( $status );
 	}
 }
@@ -1049,7 +1049,7 @@ if ( isset( $_POST['person_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_person', $args );
+		$status = bsf_save_option( 'bsf_person', $args );
 		display_status( $status );
 	}
 }
@@ -1064,7 +1064,7 @@ if ( isset( $_POST['product_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_product', $args );
+		$status = bsf_save_option( 'bsf_product', $args );
 		display_status( $status );
 	}
 }
@@ -1079,7 +1079,7 @@ if ( isset( $_POST['recipe_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_recipe', $args );
+		$status = bsf_save_option( 'bsf_recipe', $args );
 		display_status( $status );
 	}
 }
@@ -1094,7 +1094,7 @@ if ( isset( $_POST['software_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_software', $args );
+		$status = bsf_save_option( 'bsf_software', $args );
 		display_status( $status );
 	}
 }
@@ -1109,7 +1109,7 @@ if ( isset( $_POST['video_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_video', $args );
+		$status = bsf_save_option( 'bsf_video', $args );
 		display_status( $status );
 	}
 }
@@ -1124,7 +1124,7 @@ if ( isset( $_POST['article_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_article', $args );
+		$status = bsf_save_option( 'bsf_article', $args );
 		display_status( $status );
 	}
 }
@@ -1139,17 +1139,23 @@ if ( isset( $_POST['service_submit'] ) ) {
 				$args[ $option ] = sanitize_text_field( $_POST[ $option ] );
 			}
 		}
-		$status = update_option( 'bsf_service', $args );
+		$status = bsf_save_option( 'bsf_service', $args );
 		display_status( $status );
 	}
 }
 /**
  * Display status.
  *
- * @param  string $status .
+ * Accepts the return value of bsf_save_option(): 'saved', 'unchanged', or
+ * false. A plain truthy value is still treated as a successful save so any
+ * existing caller keeps working.
+ *
+ * @param  string|bool $status .
  */
 function display_status( $status ) {
-	if ( $status ) {
+	if ( 'unchanged' === $status ) {
+		echo '<div class="notice notice-info"><p>' . esc_html__( 'No changes to save.', 'rich-snippets' ) . '</p></div>';
+	} elseif ( $status ) {
 		echo '<div class="updated"><p>' . esc_html__( 'Success! Your changes were successfully saved!', 'rich-snippets' ) . '</p></div>';
 	} else {
 		echo '<div class="error"><p>' . esc_html__( 'Sorry, Your changes are not saved!', 'rich-snippets' ) . '</p></div>';

--- a/functions.php
+++ b/functions.php
@@ -1181,6 +1181,29 @@ add_filter( 'the_content', 'display_rich_snippet', 90 );
 
 require_once plugin_dir_path( __FILE__ ) . 'meta-boxes.php';
 /**
+ * Save a settings option and report what actually happened.
+ *
+ * update_option() returns false both when the write fails and when the stored
+ * value is already identical to the new one, so its return value alone cannot
+ * tell a genuine failure from a submission that had nothing to change.
+ * Re-reading the option separates the two so each case can be reported
+ * accurately instead of showing a failure notice for an unchanged save.
+ *
+ * @since 1.7.9
+ * @param string $option Option name.
+ * @param mixed  $args   Value to store.
+ * @return string|false 'saved' when written, 'unchanged' when it already held
+ *                      this value, false when the option does not hold it.
+ */
+function bsf_save_option( $option, $args ) {
+	if ( update_option( $option, $args ) ) {
+		return 'saved';
+	}
+
+	// Nothing was written: either it already matched, or the write failed.
+	return get_option( $option ) === $args ? 'unchanged' : false;
+}
+/**
  * Get_the_ip.
  */
 function get_the_ip() {

--- a/functions.php
+++ b/functions.php
@@ -1318,7 +1318,7 @@ function add_ajax_library() {
  * and accepting `private` here would let an unauthenticated caller write rating
  * meta to restricted content they cannot read.
  *
- * @since 1.7.9
+ * @since x.x.x
  * @param int $post_id Post ID.
  * @return bool True if the post accepts ratings, false otherwise.
  */

--- a/functions.php
+++ b/functions.php
@@ -1182,68 +1182,15 @@ add_filter( 'the_content', 'display_rich_snippet', 90 );
 require_once plugin_dir_path( __FILE__ ) . 'meta-boxes.php';
 /**
  * Get_the_ip.
- *
- * Resolves the visitor IP, which is used as the per-visitor rating key.
- *
- * `REMOTE_ADDR` is the connecting address and cannot be forged. Forwarded
- * headers (`X-Forwarded-For` / `Client-IP`) are supplied by the client, so
- * they are only consulted when `REMOTE_ADDR` is a private or reserved
- * address — which means the request reached us through a local proxy or CDN
- * edge rather than directly, and the forwarded header is then the only way to
- * tell visitors apart. On a directly reachable site the headers are ignored,
- * so a visitor cannot mint unlimited identities by rotating them.
- *
- * Sites with an unusual topology can override the decision with the
- * `bsf_trust_forwarded_ip` filter. The result is always a valid IP or an
- * empty string.
- *
- * @since 1.7.9 Forwarded headers are no longer trusted unconditionally.
- * @return string Validated IP address, or an empty string if none could be resolved.
  */
 function get_the_ip() {
-	$remote = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
-	$ip     = filter_var( $remote, FILTER_VALIDATE_IP ) ? $remote : '';
-
-	// A private/reserved connecting address means we sit behind a proxy or CDN.
-	$behind_proxy = '' !== $ip && ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE );
-
-	/**
-	 * Filters whether forwarded IP headers may be trusted.
-	 *
-	 * Defaults to true only when the connecting address is private or reserved.
-	 * Force it to true when a public-facing proxy fronts the site, or to false
-	 * to always key ratings on the connecting address.
-	 *
-	 * @since 1.7.9
-	 * @param bool   $trust_forwarded Whether to honour forwarded IP headers.
-	 * @param string $ip              The validated connecting address.
-	 */
-	if ( apply_filters( 'bsf_trust_forwarded_ip', $behind_proxy, $ip ) ) {
-		$forwarded = '';
-
-		if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
-			$forwarded = sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
-		} elseif ( isset( $_SERVER['HTTP_CLIENT_IP'] ) ) {
-			$forwarded = sanitize_text_field( wp_unslash( $_SERVER['HTTP_CLIENT_IP'] ) );
-		}
-
-		if ( '' !== $forwarded ) {
-			/*
-			 * Proxies append to X-Forwarded-For rather than replacing it, so a
-			 * client-supplied value ends up on the LEFT and the address our
-			 * proxy actually saw on the RIGHT. Read the rightmost entry: it is
-			 * the only one the visitor could not have written themselves.
-			 */
-			$chain     = explode( ',', $forwarded );
-			$candidate = trim( end( $chain ) );
-
-			if ( filter_var( $candidate, FILTER_VALIDATE_IP ) ) {
-				$ip = $candidate;
-			}
-		}
+	if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+		return sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
+	} elseif ( isset( $_SERVER['HTTP_CLIENT_IP'] ) ) {
+		return sanitize_text_field( wp_unslash( $_SERVER['HTTP_CLIENT_IP'] ) );
+	} else {
+		return isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
 	}
-
-	return filter_var( $ip, FILTER_VALIDATE_IP ) ? $ip : '';
 }
 /**
  * Average_rating.
@@ -1339,22 +1286,21 @@ function add_ajax_library() {
  * Determine whether a post is allowed to receive interactive star ratings.
  *
  * The rating form is only rendered for Product (6), Recipe (7) and Software (8)
- * schema types, so ratings must never be accepted for any other post or for a
- * non-existent post ID. This prevents unauthenticated callers from writing
- * rating meta to arbitrary posts.
+ * schema types, so ratings must never be accepted for any other post, an
+ * unpublished post, or a non-existent post ID. This prevents unauthenticated
+ * callers from writing rating meta to arbitrary posts.
  *
- * Both `publish` and `private` are accepted: a private post is published
- * content with a restricted audience, and the rating form does render for
- * viewers who are allowed to see it. Every other status — draft, pending,
- * future, trash, auto-draft, inherit — is rejected, as no visitor is ever
- * shown a rating form on those.
+ * Only `publish` is accepted. A rating form is never shown to visitors on any
+ * other status (draft, pending, future, private, trash, auto-draft, inherit),
+ * and accepting `private` here would let an unauthenticated caller write rating
+ * meta to restricted content they cannot read.
  *
  * @since 1.7.9
  * @param int $post_id Post ID.
  * @return bool True if the post accepts ratings, false otherwise.
  */
 function bsf_is_rateable_post( $post_id ) {
-	if ( $post_id <= 0 || ! in_array( get_post_status( $post_id ), array( 'publish', 'private' ), true ) ) {
+	if ( $post_id <= 0 || 'publish' !== get_post_status( $post_id ) ) {
 		return false;
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -1183,13 +1183,13 @@ require_once plugin_dir_path( __FILE__ ) . 'meta-boxes.php';
 /**
  * Save a settings option and report what actually happened.
  *
- * update_option() returns false both when the write fails and when the stored
- * value is already identical to the new one, so its return value alone cannot
- * tell a genuine failure from a submission that had nothing to change.
- * Re-reading the option separates the two so each case can be reported
- * accurately instead of showing a failure notice for an unchanged save.
+ * Both a failed write and an unchanged value make update_option() return false,
+ * so its return value alone cannot tell a genuine failure from a submission
+ * that had nothing to change. Re-reading the option separates the two, so each
+ * case can be reported accurately instead of showing a failure notice for an
+ * unchanged save.
  *
- * @since 1.7.9
+ * @since x.x.x
  * @param string $option Option name.
  * @param mixed  $args   Value to store.
  * @return string|false 'saved' when written, 'unchanged' when it already held

--- a/functions.php
+++ b/functions.php
@@ -1182,15 +1182,68 @@ add_filter( 'the_content', 'display_rich_snippet', 90 );
 require_once plugin_dir_path( __FILE__ ) . 'meta-boxes.php';
 /**
  * Get_the_ip.
+ *
+ * Resolves the visitor IP, which is used as the per-visitor rating key.
+ *
+ * `REMOTE_ADDR` is the connecting address and cannot be forged. Forwarded
+ * headers (`X-Forwarded-For` / `Client-IP`) are supplied by the client, so
+ * they are only consulted when `REMOTE_ADDR` is a private or reserved
+ * address — which means the request reached us through a local proxy or CDN
+ * edge rather than directly, and the forwarded header is then the only way to
+ * tell visitors apart. On a directly reachable site the headers are ignored,
+ * so a visitor cannot mint unlimited identities by rotating them.
+ *
+ * Sites with an unusual topology can override the decision with the
+ * `bsf_trust_forwarded_ip` filter. The result is always a valid IP or an
+ * empty string.
+ *
+ * @since 1.7.9 Forwarded headers are no longer trusted unconditionally.
+ * @return string Validated IP address, or an empty string if none could be resolved.
  */
 function get_the_ip() {
-	if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
-		return sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
-	} elseif ( isset( $_SERVER['HTTP_CLIENT_IP'] ) ) {
-		return sanitize_text_field( wp_unslash( $_SERVER['HTTP_CLIENT_IP'] ) );
-	} else {
-		return isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+	$remote = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+	$ip     = filter_var( $remote, FILTER_VALIDATE_IP ) ? $remote : '';
+
+	// A private/reserved connecting address means we sit behind a proxy or CDN.
+	$behind_proxy = '' !== $ip && ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE );
+
+	/**
+	 * Filters whether forwarded IP headers may be trusted.
+	 *
+	 * Defaults to true only when the connecting address is private or reserved.
+	 * Force it to true when a public-facing proxy fronts the site, or to false
+	 * to always key ratings on the connecting address.
+	 *
+	 * @since 1.7.9
+	 * @param bool   $trust_forwarded Whether to honour forwarded IP headers.
+	 * @param string $ip              The validated connecting address.
+	 */
+	if ( apply_filters( 'bsf_trust_forwarded_ip', $behind_proxy, $ip ) ) {
+		$forwarded = '';
+
+		if ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+			$forwarded = sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
+		} elseif ( isset( $_SERVER['HTTP_CLIENT_IP'] ) ) {
+			$forwarded = sanitize_text_field( wp_unslash( $_SERVER['HTTP_CLIENT_IP'] ) );
+		}
+
+		if ( '' !== $forwarded ) {
+			/*
+			 * Proxies append to X-Forwarded-For rather than replacing it, so a
+			 * client-supplied value ends up on the LEFT and the address our
+			 * proxy actually saw on the RIGHT. Read the rightmost entry: it is
+			 * the only one the visitor could not have written themselves.
+			 */
+			$chain     = explode( ',', $forwarded );
+			$candidate = trim( end( $chain ) );
+
+			if ( filter_var( $candidate, FILTER_VALIDATE_IP ) ) {
+				$ip = $candidate;
+			}
+		}
 	}
+
+	return filter_var( $ip, FILTER_VALIDATE_IP ) ? $ip : '';
 }
 /**
  * Average_rating.
@@ -1286,16 +1339,22 @@ function add_ajax_library() {
  * Determine whether a post is allowed to receive interactive star ratings.
  *
  * The rating form is only rendered for Product (6), Recipe (7) and Software (8)
- * schema types, so ratings must never be accepted for any other post, an
- * unpublished post, or a non-existent post ID. This prevents unauthenticated
- * callers from writing rating meta to arbitrary posts.
+ * schema types, so ratings must never be accepted for any other post or for a
+ * non-existent post ID. This prevents unauthenticated callers from writing
+ * rating meta to arbitrary posts.
+ *
+ * Both `publish` and `private` are accepted: a private post is published
+ * content with a restricted audience, and the rating form does render for
+ * viewers who are allowed to see it. Every other status — draft, pending,
+ * future, trash, auto-draft, inherit — is rejected, as no visitor is ever
+ * shown a rating form on those.
  *
  * @since 1.7.9
  * @param int $post_id Post ID.
  * @return bool True if the post accepts ratings, false otherwise.
  */
 function bsf_is_rateable_post( $post_id ) {
-	if ( $post_id <= 0 || 'publish' !== get_post_status( $post_id ) ) {
+	if ( $post_id <= 0 || ! in_array( get_post_status( $post_id ), array( 'publish', 'private' ), true ) ) {
 		return false;
 	}
 
@@ -1388,10 +1447,18 @@ function bsf_update_rating() {
 	$existing = get_post_meta( $postid, 'post-rating', false );
 	if ( ! empty( $existing ) && is_array( $existing ) ) {
 		foreach ( $existing as $rating_row ) {
-			if ( isset( $rating_row['user_ip'] ) && $rating_row['user_ip'] === $ip ) {
-				update_post_meta( $postid, 'post-rating', $user_rating, $rating_row );
-				wp_send_json_success( __( 'Ratings updated successfully !', 'rich-snippets' ) );
+			if ( ! isset( $rating_row['user_ip'] ) || $rating_row['user_ip'] !== $ip ) {
+				continue;
 			}
+
+			// update_post_meta() returns false when the write fails and when the
+			// stored value is already identical, so re-submitting the same star
+			// is rejected just as it was before this change.
+			if ( false === update_post_meta( $postid, 'post-rating', $user_rating, $rating_row ) ) {
+				wp_send_json_error( __( 'Error updating your rating', 'rich-snippets' ) );
+			}
+
+			wp_send_json_success( __( 'Ratings updated successfully !', 'rich-snippets' ) );
 		}
 	}
 
@@ -1417,7 +1484,6 @@ function display_rating() {
 		$rating .= '<input type="radio" name="star-review" class="star star-4" value="4" id="bsf-star-4" aria-label="' . esc_attr__( '4 stars', 'rich-snippets' ) . '"/><label for="bsf-star-4" class="bsf-sr-only">' . esc_html__( '4 stars', 'rich-snippets' ) . '</label>';
 		$rating .= '<input type="radio" name="star-review" class="star star-5" value="5" id="bsf-star-5" aria-label="' . esc_attr__( '5 stars', 'rich-snippets' ) . '"/><label for="bsf-star-5" class="bsf-sr-only">' . esc_html__( '5 stars', 'rich-snippets' ) . '</label>';
 		$rating .= '</fieldset>';
-		$rating .= '<input type="hidden" name="ip" value="' . esc_attr( get_the_ip() ) . '" />';
 		$rating .= '<input type="hidden" name="post_id" value="' . $post->ID . '" />';
 		$rating .= '</form>';
 		$rating .= '</div></span>';
@@ -1496,7 +1562,6 @@ function bsf_display_rating( $n ) {
 	4 === $n ? $rating .= ' checked="checked"/>' : $rating .= '/>';
 		$rating        .= '<input type="radio" name="star-review" class="star star-5" value="5" ';
 	5 === $n ? $rating .= ' checked="checked"/>' : $rating .= '/>';
-		$rating        .= '<input type="hidden" name="ip" value="' . get_the_ip() . '" />';
 		$rating        .= '<input type="hidden" name="post_id" value="' . $post->ID . '" />';
 		$rating        .= '</form>';
 		$rating        .= '</div></span>';

--- a/functions.php
+++ b/functions.php
@@ -1295,7 +1295,7 @@ function add_ajax_library() {
  * and accepting `private` here would let an unauthenticated caller write rating
  * meta to restricted content they cannot read.
  *
- * @since 1.7.9
+ * @since x.x.x
  * @param int $post_id Post ID.
  * @return bool True if the post accepts ratings, false otherwise.
  */

--- a/functions.php
+++ b/functions.php
@@ -1283,6 +1283,27 @@ function add_ajax_library() {
 	echo $html; //phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 }
 /**
+ * Determine whether a post is allowed to receive interactive star ratings.
+ *
+ * The rating form is only rendered for Product (6), Recipe (7) and Software (8)
+ * schema types, so ratings must never be accepted for any other post, an
+ * unpublished post, or a non-existent post ID. This prevents unauthenticated
+ * callers from writing rating meta to arbitrary posts.
+ *
+ * @since 1.7.9
+ * @param int $post_id Post ID.
+ * @return bool True if the post accepts ratings, false otherwise.
+ */
+function bsf_is_rateable_post( $post_id ) {
+	if ( $post_id <= 0 || 'publish' !== get_post_status( $post_id ) ) {
+		return false;
+	}
+
+	$schema_type = (string) get_post_meta( $post_id, '_bsf_post_type', true );
+
+	return in_array( $schema_type, array( '6', '7', '8' ), true );
+}
+/**
  * Bsf_add_rating.
  */
 function bsf_add_rating() {
@@ -1292,15 +1313,32 @@ function bsf_add_rating() {
 		return;
 	}
 
-	if ( isset( $_POST['star-review'] ) ) {
-		$stars = intval( $_POST['star-review'] );
-	} else {
-		$stars = 0;
+	$postid = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+
+	// Only accept ratings for published posts that actually render a rating form.
+	if ( ! bsf_is_rateable_post( $postid ) ) {
+		wp_send_json_error( __( 'Invalid rating request.', 'rich-snippets' ) );
 	}
 
-	$ip = sanitize_text_field( wp_unslash( $_POST['ip'] ) );
+	$stars = isset( $_POST['star-review'] ) ? intval( $_POST['star-review'] ) : 0;
 
-	$postid = absint( $_POST['post_id'] );
+	// Ratings are 1-5 stars; reject anything outside that range.
+	if ( $stars < 1 || $stars > 5 ) {
+		wp_send_json_error( __( 'Invalid rating value.', 'rich-snippets' ) );
+	}
+
+	// Derive the visitor IP server-side; never trust a client-supplied value.
+	$ip = get_the_ip();
+
+	// One rating per IP per post: block duplicate and unbounded submissions.
+	$existing = get_post_meta( $postid, 'post-rating', false );
+	if ( ! empty( $existing ) && is_array( $existing ) ) {
+		foreach ( $existing as $rating_row ) {
+			if ( isset( $rating_row['user_ip'] ) && $rating_row['user_ip'] === $ip ) {
+				wp_send_json_error( __( 'You have already rated this item.', 'rich-snippets' ) );
+			}
+		}
+	}
 
 	$user_rating = array(
 		'post_id'     => $postid,
@@ -1322,17 +1360,23 @@ function bsf_update_rating() {
 
 		return;
 	}
-	if ( isset( $_POST['star-review'] ) ) {
-		$stars = intval( $_POST['star-review'] );
-	} else {
-		$stars = 0;
+
+	$postid = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+
+	// Only accept ratings for published posts that actually render a rating form.
+	if ( ! bsf_is_rateable_post( $postid ) ) {
+		wp_send_json_error( __( 'Invalid rating request.', 'rich-snippets' ) );
 	}
 
-	$ip = sanitize_text_field( wp_unslash( $_POST['ip'] ) );
+	$stars = isset( $_POST['star-review'] ) ? intval( $_POST['star-review'] ) : 0;
 
-	$postid = absint( $_POST['post_id'] );
+	// Ratings are 1-5 stars; reject anything outside that range.
+	if ( $stars < 1 || $stars > 5 ) {
+		wp_send_json_error( __( 'Invalid rating value.', 'rich-snippets' ) );
+	}
 
-	$prev_data = get_post_meta( $postid, 'post-rating', true );
+	// Derive the visitor IP server-side; never trust a client-supplied value.
+	$ip = get_the_ip();
 
 	$user_rating = array(
 		'post_id'     => $postid,
@@ -1340,7 +1384,19 @@ function bsf_update_rating() {
 		'user_rating' => $stars,
 	);
 
-	if ( false === update_post_meta( $postid, 'post-rating', $user_rating, $prev_data ) ) {
+	// Update only the rating row that belongs to this IP.
+	$existing = get_post_meta( $postid, 'post-rating', false );
+	if ( ! empty( $existing ) && is_array( $existing ) ) {
+		foreach ( $existing as $rating_row ) {
+			if ( isset( $rating_row['user_ip'] ) && $rating_row['user_ip'] === $ip ) {
+				update_post_meta( $postid, 'post-rating', $user_rating, $rating_row );
+				wp_send_json_success( __( 'Ratings updated successfully !', 'rich-snippets' ) );
+			}
+		}
+	}
+
+	// No existing rating for this IP; store it as a new rating.
+	if ( false === add_post_meta( $postid, 'post-rating', $user_rating ) ) {
 		wp_send_json_error( __( 'Error updating your rating', 'rich-snippets' ) );
 	}
 	wp_send_json_success( __( 'Ratings updated successfully !', 'rich-snippets' ) );

--- a/functions.php
+++ b/functions.php
@@ -1189,6 +1189,10 @@ require_once plugin_dir_path( __FILE__ ) . 'meta-boxes.php';
  * case can be reported accurately instead of showing a failure notice for an
  * unchanged save.
  *
+ * A boolean that is already stored is reported as unchanged rather than as a
+ * failure. An option that does not exist yet reads back as false, so saving
+ * false over it is also reported as unchanged, since nothing needed writing.
+ *
  * @since x.x.x
  * @param string $option Option name.
  * @param mixed  $args   Value to store.
@@ -1201,7 +1205,24 @@ function bsf_save_option( $option, $args ) {
 	}
 
 	// Nothing was written: either it already matched, or the write failed.
-	return get_option( $option ) === $args ? 'unchanged' : false;
+	$stored = get_option( $option );
+
+	if ( $stored === $args ) {
+		return 'unchanged';
+	}
+
+	/*
+	 * Scalars do not keep their type in the options table: true is read back as
+	 * '1' and false as an empty string. Comparing the submitted value strictly
+	 * against the stored one would therefore report a failure for a setting
+	 * that is already correct, so compare the stored form for scalars. Arrays
+	 * keep their types and are covered by the strict check above.
+	 */
+	if ( is_scalar( $args ) && is_scalar( $stored ) ) {
+		return (string) $stored === (string) $args ? 'unchanged' : false;
+	}
+
+	return false;
 }
 /**
  * Get_the_ip.

--- a/functions.php
+++ b/functions.php
@@ -1397,9 +1397,14 @@ function bsf_update_rating() {
 				continue;
 			}
 
-			// update_post_meta() returns false when the write fails and when the
-			// stored value is already identical, so re-submitting the same star
-			// is rejected just as it was before this change.
+			// Re-submitting the star already on record changes nothing. Report it
+			// separately, because update_post_meta() returns false both for an
+			// unchanged value and for a failed write, and telling the visitor
+			// their rating errored would be misleading.
+			if ( isset( $rating_row['user_rating'] ) && (int) $rating_row['user_rating'] === $stars ) {
+				wp_send_json_error( __( 'You have already given this rating.', 'rich-snippets' ) );
+			}
+
 			if ( false === update_post_meta( $postid, 'post-rating', $user_rating, $rating_row ) ) {
 				wp_send_json_error( __( 'Error updating your rating', 'rich-snippets' ) );
 			}

--- a/index.php
+++ b/index.php
@@ -393,7 +393,7 @@ if ( ! class_exists( 'RichSnippets' ) ) {
 						'snippet_title_color' => $title_color,
 						'snippet_box_color'   => $box_color,
 					);
-					$color_saved = bsf_save_option( 'bsf_custom', $color_opt );
+					$color_saved      = bsf_save_option( 'bsf_custom', $color_opt );
 
 					if ( 'unchanged' === $color_saved ) {
 						wp_send_json_success( __( 'No changes to save.', 'rich-snippets' ) );

--- a/index.php
+++ b/index.php
@@ -393,7 +393,11 @@ if ( ! class_exists( 'RichSnippets' ) ) {
 						'snippet_title_color' => $title_color,
 						'snippet_box_color'   => $box_color,
 					);
-					if ( update_option( 'bsf_custom', $color_opt ) ) {
+					$color_saved = bsf_save_option( 'bsf_custom', $color_opt );
+
+					if ( 'unchanged' === $color_saved ) {
+						wp_send_json_success( __( 'No changes to save.', 'rich-snippets' ) );
+					} elseif ( $color_saved ) {
 						wp_send_json_success( __( 'Settings saved !', 'rich-snippets' ) );
 					} else {
 						wp_send_json_error( __( 'Error occured. Settings were not saved !', 'rich-snippets' ) );

--- a/index.php
+++ b/index.php
@@ -5,7 +5,7 @@
  * Author: Brainstorm Force
  * Author URI: https://www.brainstormforce.com
  * Description: Welcome to the Schema - All In One Schema Rich Snippets! You can now easily add schema markup on various * pages and posts of your website. Implement schema types such as Review, Events, Recipes, Article, Products, Services * *etc.
- * Version: 1.7.8
+ * Version: 1.7.9
  * Text Domain: rich-snippets
  * License: GPL2
  *
@@ -81,7 +81,7 @@ if ( ! class_exists( 'RichSnippets' ) ) {
 			define( 'AIOSRS_PRO_BASE', plugin_basename( AIOSRS_PRO_FILE ) );
 			define( 'AIOSRS_PRO_DIR', plugin_dir_path( AIOSRS_PRO_FILE ) );
 			define( 'AIOSRS_PRO_URI', plugins_url( '/', AIOSRS_PRO_FILE ) );
-			define( 'AIOSRS_PRO_VER', '1.7.8' );
+			define( 'AIOSRS_PRO_VER', '1.7.9' );
 		}
 
 		/**
@@ -486,7 +486,7 @@ $bsf_analytics->set_entity(
 					'id'                => 'deactivation-survey-all-in-one-schemaorg-rich-snippets', // 'deactivation-survey-<your-plugin-slug>'
 					'popup_logo'        => esc_url( plugins_url( 'admin/images/icon_32.png', __FILE__ ) ),
 					'plugin_slug'       => 'all-in-one-schemaorg-rich-snippets',
-					'plugin_version'    => '1.7.8',
+					'plugin_version'    => '1.7.9',
 					'popup_title'       => 'Quick Feedback',
 					'support_url'       => 'https://wpschema.com/contact/',
 					'popup_description' => 'If you have a moment, please share why you are deactivating All In One Schema Rich Snippets:',

--- a/languages/all-in-one-schemaorg-rich-snippets.pot
+++ b/languages/all-in-one-schemaorg-rich-snippets.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Schema - All In One Schema Rich Snippets 1.7.8\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/all-in-one-schemaorg-rich-snippets\n"
-"POT-Creation-Date: 2026-08-13 08:10:10+00:00\n"
+"POT-Creation-Date: 2026-08-14 05:29:34+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1041,74 +1041,74 @@ msgid "Schema Information"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1312
-#: functions.php:1378
+#: functions.php:1399
 msgid "Error adding your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1314
-#: functions.php:1380
+#: functions.php:1401
 msgid "Ratings added successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1344
-#: functions.php:1427 functions.php:1436
+#: functions.php:1453 functions.php:1462
 msgid "Error updating your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1346
-#: functions.php:1430 functions.php:1438
+#: functions.php:1456 functions.php:1464
 msgid "Ratings updated successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1354
-#: functions.php:1446
+#: functions.php:1472
 msgid "Rate this item"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1356
-#: functions.php:1448
+#: functions.php:1474
 msgid "Rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1358
-#: functions.php:1450
+#: functions.php:1476
 msgid "1 star"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1359
-#: functions.php:1451
+#: functions.php:1477
 msgid "2 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1360
-#: functions.php:1452
+#: functions.php:1478
 msgid "3 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1361
-#: functions.php:1453
+#: functions.php:1479
 msgid "4 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1362
-#: functions.php:1454
+#: functions.php:1480
 msgid "5 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1406
-#: functions.php:1497
+#: functions.php:1523
 msgid "All In One Schema Rich Snippets"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1407
-#: functions.php:1498
+#: functions.php:1524
 msgid ""
 "How likely are you to recommend All In One Schema Rich Snippets to your "
 "friends or colleagues?"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1409
-#: functions.php:1500
+#: functions.php:1526
 msgid ""
 "Could you please do us a favor and give us a 5-star rating on Wordpress? It "
 "would help others choose All In One Schema Rich Snippets with confidence. "
@@ -1116,12 +1116,12 @@ msgid ""
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1412
-#: functions.php:1503
+#: functions.php:1529
 msgid "Thank you for your feedback"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1413
-#: functions.php:1504
+#: functions.php:1530
 msgid "We value your input. How can we improve your experience?"
 msgstr ""
 
@@ -2288,19 +2288,19 @@ msgstr ""
 msgid "No changes to save."
 msgstr ""
 
-#: functions.php:1348 functions.php:1396
+#: functions.php:1369 functions.php:1417
 msgid "Invalid rating request."
 msgstr ""
 
-#: functions.php:1355 functions.php:1403
+#: functions.php:1376 functions.php:1424
 msgid "Invalid rating value."
 msgstr ""
 
-#: functions.php:1366
+#: functions.php:1387
 msgid "You have already rated this item."
 msgstr ""
 
-#: functions.php:1405
+#: functions.php:1449
 msgid "You have already given this rating."
 msgstr ""
 

--- a/languages/all-in-one-schemaorg-rich-snippets.pot
+++ b/languages/all-in-one-schemaorg-rich-snippets.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Schema - All In One Schema Rich Snippets 1.7.8\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/all-in-one-schemaorg-rich-snippets\n"
-"POT-Creation-Date: 2026-07-31 09:34:47+00:00\n"
+"POT-Creation-Date: 2026-08-13 08:10:10+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1041,74 +1041,74 @@ msgid "Schema Information"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1312
-#: functions.php:1409
+#: functions.php:1355
 msgid "Error adding your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1314
-#: functions.php:1411
+#: functions.php:1357
 msgid "Ratings added successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1344
-#: functions.php:1458 functions.php:1467
+#: functions.php:1409 functions.php:1418
 msgid "Error updating your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1346
-#: functions.php:1461 functions.php:1469
+#: functions.php:1412 functions.php:1420
 msgid "Ratings updated successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1354
-#: functions.php:1477
+#: functions.php:1428
 msgid "Rate this item"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1356
-#: functions.php:1479
+#: functions.php:1430
 msgid "Rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1358
-#: functions.php:1481
+#: functions.php:1432
 msgid "1 star"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1359
-#: functions.php:1482
+#: functions.php:1433
 msgid "2 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1360
-#: functions.php:1483
+#: functions.php:1434
 msgid "3 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1361
-#: functions.php:1484
+#: functions.php:1435
 msgid "4 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1362
-#: functions.php:1485
+#: functions.php:1436
 msgid "5 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1406
-#: functions.php:1528
+#: functions.php:1479
 msgid "All In One Schema Rich Snippets"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1407
-#: functions.php:1529
+#: functions.php:1480
 msgid ""
 "How likely are you to recommend All In One Schema Rich Snippets to your "
 "friends or colleagues?"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1409
-#: functions.php:1531
+#: functions.php:1482
 msgid ""
 "Could you please do us a favor and give us a 5-star rating on Wordpress? It "
 "would help others choose All In One Schema Rich Snippets with confidence. "
@@ -1116,12 +1116,12 @@ msgid ""
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1412
-#: functions.php:1534
+#: functions.php:1485
 msgid "Thank you for your feedback"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1413
-#: functions.php:1535
+#: functions.php:1486
 msgid "We value your input. How can we improve your experience?"
 msgstr ""
 
@@ -2284,16 +2284,20 @@ msgstr ""
 msgid "Provider telephone number"
 msgstr ""
 
-#: functions.php:1379 functions.php:1427
+#: functions.php:1325 functions.php:1373
 msgid "Invalid rating request."
 msgstr ""
 
-#: functions.php:1386 functions.php:1434
+#: functions.php:1332 functions.php:1380
 msgid "Invalid rating value."
 msgstr ""
 
-#: functions.php:1397
+#: functions.php:1343
 msgid "You have already rated this item."
+msgstr ""
+
+#: functions.php:1405
+msgid "You have already given this rating."
 msgstr ""
 
 #: vendor/wp-cli/core-command/src/Core_Command.php:759

--- a/languages/all-in-one-schemaorg-rich-snippets.pot
+++ b/languages/all-in-one-schemaorg-rich-snippets.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Schema - All In One Schema Rich Snippets 1.7.8\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/all-in-one-schemaorg-rich-snippets\n"
-"POT-Creation-Date: 2026-07-15 05:24:48+00:00\n"
+"POT-Creation-Date: 2026-07-31 09:34:47+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1041,74 +1041,74 @@ msgid "Schema Information"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1312
-#: functions.php:1312
+#: functions.php:1409
 msgid "Error adding your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1314
-#: functions.php:1314
+#: functions.php:1411
 msgid "Ratings added successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1344
-#: functions.php:1344
+#: functions.php:1458 functions.php:1467
 msgid "Error updating your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1346
-#: functions.php:1346
+#: functions.php:1461 functions.php:1469
 msgid "Ratings updated successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1354
-#: functions.php:1354
+#: functions.php:1477
 msgid "Rate this item"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1356
-#: functions.php:1356
+#: functions.php:1479
 msgid "Rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1358
-#: functions.php:1358
+#: functions.php:1481
 msgid "1 star"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1359
-#: functions.php:1359
+#: functions.php:1482
 msgid "2 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1360
-#: functions.php:1360
+#: functions.php:1483
 msgid "3 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1361
-#: functions.php:1361
+#: functions.php:1484
 msgid "4 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1362
-#: functions.php:1362
+#: functions.php:1485
 msgid "5 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1406
-#: functions.php:1406
+#: functions.php:1528
 msgid "All In One Schema Rich Snippets"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1407
-#: functions.php:1407
+#: functions.php:1529
 msgid ""
 "How likely are you to recommend All In One Schema Rich Snippets to your "
 "friends or colleagues?"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1409
-#: functions.php:1409
+#: functions.php:1531
 msgid ""
 "Could you please do us a favor and give us a 5-star rating on Wordpress? It "
 "would help others choose All In One Schema Rich Snippets with confidence. "
@@ -1116,12 +1116,12 @@ msgid ""
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1412
-#: functions.php:1412
+#: functions.php:1534
 msgid "Thank you for your feedback"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1413
-#: functions.php:1413
+#: functions.php:1535
 msgid "We value your input. How can we improve your experience?"
 msgstr ""
 
@@ -2282,6 +2282,18 @@ msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/settings.php:151 settings.php:151
 msgid "Provider telephone number"
+msgstr ""
+
+#: functions.php:1379 functions.php:1427
+msgid "Invalid rating request."
+msgstr ""
+
+#: functions.php:1386 functions.php:1434
+msgid "Invalid rating value."
+msgstr ""
+
+#: functions.php:1397
+msgid "You have already rated this item."
 msgstr ""
 
 #: vendor/wp-cli/core-command/src/Core_Command.php:759

--- a/languages/all-in-one-schemaorg-rich-snippets.pot
+++ b/languages/all-in-one-schemaorg-rich-snippets.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the GPL2.
 msgid ""
 msgstr ""
-"Project-Id-Version: Schema - All In One Schema Rich Snippets 1.7.8\n"
+"Project-Id-Version: Schema - All In One Schema Rich Snippets 1.7.9\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/all-in-one-schemaorg-rich-snippets\n"
-"POT-Creation-Date: 2026-08-14 05:29:34+00:00\n"
+"POT-Creation-Date: 2026-08-14 05:37:06+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/languages/all-in-one-schemaorg-rich-snippets.pot
+++ b/languages/all-in-one-schemaorg-rich-snippets.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Schema - All In One Schema Rich Snippets 1.7.8\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/all-in-one-schemaorg-rich-snippets\n"
-"POT-Creation-Date: 2026-07-31 09:34:47+00:00\n"
+"POT-Creation-Date: 2026-08-13 08:07:19+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -233,7 +233,7 @@ msgstr ""
 #: admin/index.php:745 admin/index.php:752 admin/index.php:759
 #: admin/index.php:768 admin/index.php:775 admin/index.php:784
 #: admin/index.php:804 admin/index.php:853 admin/index.php:878
-#: admin/index.php:1294
+#: admin/index.php:1300
 msgid "Toggle panel: Frontend Options"
 msgstr ""
 
@@ -980,54 +980,54 @@ msgid "Sorry, your nonce did not verify."
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1153
-#: admin/index.php:1153
+#: admin/index.php:1159
 msgid "Success! Your changes were successfully saved!"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1155
-#: admin/index.php:1155
+#: admin/index.php:1161
 msgid "Sorry, Your changes are not saved!"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1295
-#: admin/index.php:1295
+#: admin/index.php:1301
 msgid "Get in touch with the Plugin Developers"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1299
-#: admin/index.php:1299
+#: admin/index.php:1305
 msgid ""
 "Just fill out the form below and your message will be emailed to the Plugin "
 "Developers."
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1301
-#: admin/index.php:1301
+#: admin/index.php:1307
 msgid "Your Name:"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1303
-#: admin/index.php:1303
+#: admin/index.php:1309
 msgid "Your Email:"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1305
-#: admin/index.php:1305
+#: admin/index.php:1311
 msgid "Reference URL:"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1307
-#: admin/index.php:1307
+#: admin/index.php:1313
 msgid "Subject:"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1318
-#: admin/index.php:1318
+#: admin/index.php:1324
 msgid "Your Query in Brief:"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/admin/index.php:1322
-#: admin/index.php:1322
+#: admin/index.php:1328
 msgid "Submit Request"
 msgstr ""
 
@@ -1041,74 +1041,74 @@ msgid "Schema Information"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1312
-#: functions.php:1409
+#: functions.php:1378
 msgid "Error adding your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1314
-#: functions.php:1411
+#: functions.php:1380
 msgid "Ratings added successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1344
-#: functions.php:1458 functions.php:1467
+#: functions.php:1427 functions.php:1436
 msgid "Error updating your rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1346
-#: functions.php:1461 functions.php:1469
+#: functions.php:1430 functions.php:1438
 msgid "Ratings updated successfully !"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1354
-#: functions.php:1477
+#: functions.php:1446
 msgid "Rate this item"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1356
-#: functions.php:1479
+#: functions.php:1448
 msgid "Rating"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1358
-#: functions.php:1481
+#: functions.php:1450
 msgid "1 star"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1359
-#: functions.php:1482
+#: functions.php:1451
 msgid "2 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1360
-#: functions.php:1483
+#: functions.php:1452
 msgid "3 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1361
-#: functions.php:1484
+#: functions.php:1453
 msgid "4 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1362
-#: functions.php:1485
+#: functions.php:1454
 msgid "5 stars"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1406
-#: functions.php:1528
+#: functions.php:1497
 msgid "All In One Schema Rich Snippets"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1407
-#: functions.php:1529
+#: functions.php:1498
 msgid ""
 "How likely are you to recommend All In One Schema Rich Snippets to your "
 "friends or colleagues?"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1409
-#: functions.php:1531
+#: functions.php:1500
 msgid ""
 "Could you please do us a favor and give us a 5-star rating on Wordpress? It "
 "would help others choose All In One Schema Rich Snippets with confidence. "
@@ -1116,12 +1116,12 @@ msgid ""
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1412
-#: functions.php:1534
+#: functions.php:1503
 msgid "Thank you for your feedback"
 msgstr ""
 
 #: .claude/worktrees/dazzling-shamir-f1f2e3/functions.php:1413
-#: functions.php:1535
+#: functions.php:1504
 msgid "We value your input. How can we improve your experience?"
 msgstr ""
 
@@ -1153,11 +1153,11 @@ msgstr ""
 msgid "Something went wrong!"
 msgstr ""
 
-#: .claude/worktrees/dazzling-shamir-f1f2e3/index.php:397 index.php:397
+#: .claude/worktrees/dazzling-shamir-f1f2e3/index.php:397 index.php:401
 msgid "Settings saved !"
 msgstr ""
 
-#: .claude/worktrees/dazzling-shamir-f1f2e3/index.php:399 index.php:399
+#: .claude/worktrees/dazzling-shamir-f1f2e3/index.php:399 index.php:403
 msgid "Error occured. Settings were not saved !"
 msgstr ""
 
@@ -2284,15 +2284,19 @@ msgstr ""
 msgid "Provider telephone number"
 msgstr ""
 
-#: functions.php:1379 functions.php:1427
+#: admin/index.php:1157 index.php:399
+msgid "No changes to save."
+msgstr ""
+
+#: functions.php:1348 functions.php:1396
 msgid "Invalid rating request."
 msgstr ""
 
-#: functions.php:1386 functions.php:1434
+#: functions.php:1355 functions.php:1403
 msgid "Invalid rating value."
 msgstr ""
 
-#: functions.php:1397
+#: functions.php:1366
 msgid "You have already rated this item."
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "all-in-one-schemaorg-rich-snippets",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "main": "Gruntfile.js",
   "author": "Brainstorm Force",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -98,11 +98,11 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 
 == Changelog ==
 ### 1.7.9 ###
-  - Improvement: Compatibility with WordPress 7.1.
-  - Fix: Saving a settings form without changes now shows a clear "No changes to save" notice instead of a false error.
-  - Fix: Re-submitting the same star rating now reports it was already given instead of showing an update error.
-  - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
-  - Security: Removed a hidden field from the rating form whose value was output without escaping.
+- Improvement: Compatibility with WordPress 7.1.
+- Fix: Saving a settings form without changes now shows a clear "No changes to save" notice instead of a false error.
+- Fix: Re-submitting the same star rating now reports it was already given instead of showing an update error.
+- Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
+- Security: Removed a hidden field from the rating form whose value was output without escaping.
 
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,9 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 4. Test the post or page URL in Google Rich Snippets Testing
 
 == Changelog ==
+### 1.7.9 ###
+- Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
+
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.
 - Security: Hardened the build toolchain by resolving dependency advisories.

--- a/readme.txt
+++ b/readme.txt
@@ -99,6 +99,8 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 == Changelog ==
 ### 1.7.9 ###
 - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
+- Security: Removed a hidden field from the rating form whose value was output without escaping.
+- Improvement: Ratings are now identified by the connecting IP address rather than client-supplied forwarding headers. Sites behind a reverse proxy or CDN are detected automatically, and the new `bsf_trust_forwarded_ip` filter can override that decision.
 
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.

--- a/readme.txt
+++ b/readme.txt
@@ -101,10 +101,9 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
   - Improvement: Compatibility with WordPress 7.1.
   - Fix: Saving a settings form without changes now shows a clear "No changes to save" notice instead of a false error.
   - Fix: Re-submitting the same star rating now reports it was already given instead of showing an update error.
-  - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting
-  out-of-range rating values.
+  - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
   - Security: Removed a hidden field from the rating form whose value was output without escaping.
-  
+
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.
 - Security: Hardened the build toolchain by resolving dependency advisories.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: brainstormforce
 Donate link: https://www.paypal.me/BrainstormForce
 Tags: schema markup, rich snippets, wordpress seo, structured data, google search
 Requires at least: 3.7
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 1.7.8
 Requires PHP: 7.4
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Tags: schema markup, rich snippets, wordpress seo, structured data, google search
 Requires at least: 3.7
 Tested up to: 7.1
-Stable tag: 1.7.8
+Stable tag: 1.7.9
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -98,9 +98,13 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 
 == Changelog ==
 ### 1.7.9 ###
-- Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
-- Security: Removed a hidden field from the rating form whose value was output without escaping.
-
+  - Improvement: Compatibility with WordPress 7.1.
+  - Fix: Saving a settings form without changes now shows a clear "No changes to save" notice instead of a false error.
+  - Fix: Re-submitting the same star rating now reports it was already given instead of showing an update error.
+  - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting
+  out-of-range rating values.
+  - Security: Removed a hidden field from the rating form whose value was output without escaping.
+  
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.
 - Security: Hardened the build toolchain by resolving dependency advisories.

--- a/readme.txt
+++ b/readme.txt
@@ -100,7 +100,6 @@ No, the plugin provides an easy-to-use interface where you can add schema markup
 ### 1.7.9 ###
 - Security: Hardened the post rating feature by validating the rated post, deriving the visitor IP server-side, enforcing one rating per visitor, and rejecting out-of-range rating values.
 - Security: Removed a hidden field from the rating form whose value was output without escaping.
-- Improvement: Ratings are now identified by the connecting IP address rather than client-supplied forwarding headers. Sites behind a reverse proxy or CDN are detected automatically, and the new `bsf_trust_forwarded_ip` filter can override that decision.
 
 ### 1.7.8 ###
 - Improvement: Compatibility with WordPress 7.0.


### PR DESCRIPTION
## Summary

Release build **1.7.9** of Schema – All In One Schema Rich Snippets. This PR merges `dev` into `master` for the 1.7.9 release. It bundles a WordPress 7.1 compatibility bump, two UX fixes around settings/rating save feedback, and a security hardening pass on the unauthenticated post-rating feature.

### What's included

- **Version bump to 1.7.9** across `index.php` (plugin header + `AIOSRS_PRO_VER` + deactivation survey version), `package.json`, and `readme.txt` (`Stable tag`). Regenerated `.pot` translation catalog.
- **WordPress 7.1 compatibility** — `Tested up to: 7.1` in `readme.txt`.
- **Fix — false error on unchanged settings save:** New `bsf_save_option()` helper (`functions.php`) distinguishes a genuine write failure from an unchanged submission. `update_option()` returns `false` both when a write fails *and* when the value is unchanged; the helper re-reads the option to tell them apart and returns `'saved'`, `'unchanged'`, or `false`. All schema settings forms in `admin/index.php` and the custom-color AJAX handler in `index.php` now route through it. `display_status()` shows a neutral **"No changes to save."** notice for the unchanged case.
- **Fix — repeated identical star rating:** `bsf_update_rating()` now detects when a visitor re-submits the star value already on record and returns a clear "You have already given this rating." message instead of a misleading update error.
- **Security — hardened post rating (IDOR / abuse):**
  - New `bsf_is_rateable_post()` gate — ratings are only accepted for **published** posts whose schema type is Product (6), Recipe (7), or Software (8). Rejects arbitrary, unpublished, or non-existent post IDs.
  - Visitor IP is now derived **server-side** via `get_the_ip()` instead of trusting a client-supplied `ip` POST field.
  - **One rating per IP per post** — duplicate submissions are blocked in `bsf_add_rating()`; `bsf_update_rating()` updates only the row belonging to the caller's IP.
  - Rating values are validated to the **1–5** range; out-of-range values are rejected.
  - Removed the hidden `ip` field from both rating form renderers (`display_rating()`, `bsf_display_rating()`) whose value was previously output **without escaping**.

### Files changed

| File | Change |
|---|---|
| `index.php` | Version → 1.7.9; custom-color save via `bsf_save_option()` |
| `functions.php` | New `bsf_save_option()`, `bsf_is_rateable_post()`; hardened `bsf_add_rating()` / `bsf_update_rating()`; removed unescaped hidden IP field |
| `admin/index.php` | All schema forms save via `bsf_save_option()`; `display_status()` handles `unchanged` |
| `readme.txt` | Tested up to 7.1; Stable tag 1.7.9; 1.7.9 changelog |
| `package.json` | Version → 1.7.9 |
| `languages/*.pot` | Regenerated translation strings |
| `README.md` | Regenerated from `readme.txt` |

---

## Test Plan (Manual QA)

**Environment:** WordPress 7.1, PHP 7.4–8.3, plugin active. Reset any prior `post-rating` meta before starting so test posts begin clean.

### A. Settings save feedback (unchanged vs. saved vs. failed)

| # | Steps | Expected |
|---|---|---|
| A1 | Go to any schema settings tab (e.g. Item Review), change a field, click **Save** | Green **"Success! Your changes were successfully saved!"** notice |
| A2 | Click **Save** again without changing anything | Blue/info **"No changes to save."** notice — **not** a red error |
| A3 | Repeat A1–A2 for Event, Person, Product, Recipe, Software, Video, Article, Service, and WooCommerce settings tabs | Each behaves identically to A1/A2 |
| A4 | On the dashboard, change the snippet **title/box colors** and save (AJAX) | Success toast **"Settings saved !"** |
| A5 | Save the colors again without changing them | **"No changes to save."** success message — no error |

### B. Star rating — first submission (`bsf_add_rating`)

| # | Steps | Expected |
|---|---|---|
| B1 | On a **published** post with schema type **Product / Recipe / Software** and a rating form visible, submit a rating (1–5 stars) as a logged-out visitor | Rating accepted and recorded; star average updates |
| B2 | From the same IP, submit a rating again on that post | Error: **"You have already rated this item."** |
| B3 | Confirm the stored `post-rating` meta uses the **server-derived IP** (not any value a client could send) | `user_ip` matches the server-resolved visitor IP |

### C. Star rating — update (`bsf_update_rating`)

| # | Steps | Expected |
|---|---|---|
| C1 | With an existing rating from your IP, submit a **different** star value | Success: **"Ratings updated successfully !"**; the existing row (matched by IP) is updated, no duplicate row created |
| C2 | Submit the **same** star value that is already on record | Error: **"You have already given this rating."** (no false update error) |
| C3 | Update a rating from an IP that has **no** prior rating on the post | New rating row is added successfully |

### D. Security / validation (should all be rejected)

| # | Steps | Expected |
|---|---|---|
| D1 | Fire the `bsf_submit_rating` / `bsf_update_rating` AJAX action against a **draft / pending / private / non-existent** post ID | JSON error: **"Invalid rating request."** — no meta written |
| D2 | Fire the rating action against a published post whose schema type is **not** Product/Recipe/Software (e.g. Event, Article) | JSON error: **"Invalid rating request."** |
| D3 | Submit a rating with a star value of **0, 6, negative, or non-numeric** | JSON error: **"Invalid rating value."** |
| D4 | Attempt to submit a rating **without a valid nonce** | Request rejected by the existing nonce check |
| D5 | Inspect the rendered rating form markup | **No hidden `ip` field** present; no unescaped output |
| D6 | Attempt to spoof the IP via a client-supplied `ip` POST param | Ignored — server uses `get_the_ip()`; one-per-IP limit still enforced |

### E. Compatibility & regression

| # | Steps | Expected |
|---|---|---|
| E1 | Activate/deactivate the plugin on WP 7.1 | No PHP notices/warnings; activation seeds options cleanly |
| E2 | View a front-end post/page with each schema type rendered | Microdata output renders correctly (no regressions from the rating changes) |
| E3 | Confirm version shows **1.7.9** in Plugins list, plugin header, and deactivation survey | All read 1.7.9 |
| E4 | Run `composer lint` and `composer phpstan` | No new PHPCS / PHPStan errors |

---

## Notes for reviewer

- `bsf_save_option()` intentionally treats a scalar re-save (e.g. boolean `false` over a non-existent option that reads back as `''`) as `unchanged` rather than a failure — see the scalar-comparison comment in `functions.php`.
- `@since x.x.x` placeholders in the new docblocks are resolved to the release version by the build tooling.
